### PR TITLE
fix: fix z_pos when there is no z_plan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,11 @@ repos:
       - id: autoflake
         args: ["--in-place", "--remove-all-unused-imports"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.9.2
+    rev: 5.9.3
     hooks:
       - id: isort
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.23.0
+    rev: v2.23.1
     hooks:
       - id: pyupgrade
         args: ["--py3-plus", "--keep-runtime-typing"]

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -152,3 +152,13 @@ def test_combinations(
 def test_schema(cls: BaseModel) -> None:
     assert cls.schema()
     assert cls.schema_json()
+
+
+def test_z_position() -> None:
+    mda = MDASequence(
+        axis_order="tpcz",
+        stage_positions=[(222, 1, 10), (111, 1, 20)]
+    )
+    assert not mda.z_plan
+    for event in mda:
+        assert event.z_pos

--- a/useq/_mda_sequence.py
+++ b/useq/_mda_sequence.py
@@ -195,7 +195,9 @@ class MDASequence(UseqModel):
                 z_pos = (
                     self._combine_z(_ev[Z][1], index[Z], channel, position)
                     if Z in _ev
-                    else position.z if position else None
+                    else position.z
+                    if position
+                    else None
                 )
             except self._SkipFrame:
                 continue

--- a/useq/_mda_sequence.py
+++ b/useq/_mda_sequence.py
@@ -62,7 +62,8 @@ class MDASequence(UseqModel):
         if not isinstance(v, str):
             raise TypeError(f"acquisition order must be a string, got {type(v)}")
         order = v.lower()
-        if extra := {x for x in order if x not in INDICES}:
+        extra = {x for x in order if x not in INDICES}
+        if extra:
             raise ValueError(
                 f"Can only iterate over axes: {INDICES!r}. Got extra: {extra}"
             )

--- a/useq/_mda_sequence.py
+++ b/useq/_mda_sequence.py
@@ -35,9 +35,7 @@ class MDASequence(UseqModel):
 
     @validator("z_plan", pre=True)
     def validate_zplan(cls, v):  # type: ignore
-        if not v:
-            return NoZ()
-        return v
+        return v or NoZ()
 
     @validator("time_plan", pre=True)
     def validate_time_plan(cls, v):  # type: ignore
@@ -61,8 +59,7 @@ class MDASequence(UseqModel):
         if not isinstance(v, str):
             raise TypeError(f"acquisition order must be a string, got {type(v)}")
         order = v.lower()
-        extra = {x for x in order if x not in INDICES}
-        if extra:
+        if extra := {x for x in order if x not in INDICES}:
             raise ValueError(
                 f"Can only iterate over axes: {INDICES!r}. Got extra: {extra}"
             )
@@ -141,12 +138,10 @@ class MDASequence(UseqModel):
         self.channels = tuple(i for i in self.channels if i not in to_pop)
 
     def __str__(self) -> str:
-        out = "Multi-Dimensional Acquisition ▶ "
         shape = [
             f"n{k.lower()}: {len(list(self.iter_axis(k)))}" for k in self.axis_order
         ]
-        out += ", ".join(shape)
-        return out
+        return "Multi-Dimensional Acquisition ▶ " + ", ".join(shape)
 
     # def __len__(self):
     #     # np.prod(self.shape)
@@ -197,7 +192,7 @@ class MDASequence(UseqModel):
                 z_pos = (
                     self._combine_z(_ev[Z][1], index[Z], channel, position)
                     if Z in _ev
-                    else None
+                    else position.z if position else None
                 )
             except self._SkipFrame:
                 continue


### PR DESCRIPTION
At the moment, when there is _**no**_ `z_plan` (`NoZ`), when we set the stage to move and acquire images at different xy positions (e.g. through the `napari-micromanager` `mda` position table), the `z_pos` is always `None` even if it is defined in the experiment.

This PR fix this problem in the `iter_events` methods of the `MDASequence` class.