### PR TITLE
feat: Make all models and fields frozen (except metadata)

### DIFF
--- a/useq/_base_model.py
+++ b/useq/_base_model.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from pydantic import BaseModel
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
@@ -12,15 +22,19 @@ if TYPE_CHECKING:
     ReprArgs = Sequence[Tuple[Optional[str], Any]]
 
 
-__all__ = ["UseqModel"]
+__all__ = ["UseqModel", "FrozenModel"]
+
+_Y = TypeVar("_Y", bound="UseqModel")
 
 
-class UseqModel(BaseModel):
+class FrozenModel(BaseModel):
     class Config:
         allow_population_by_field_name = True
-        extra = "forbid"
-        validate_assignment = True
+        extra = "ignore"
+        frozen = True
 
+
+class UseqModel(FrozenModel):
     def __repr_args__(self) -> ReprArgs:
         return [
             (k, val)
@@ -60,14 +74,14 @@ class UseqModel(BaseModel):
 
     @classmethod
     def parse_raw(
-        cls: Type[UseqModel],
+        cls: Type[_Y],
         b: StrBytes,
         *,
         content_type: Optional[str] = None,
         encoding: str = "utf8",
         proto: Optional[str] = None,
         allow_pickle: bool = False,
-    ) -> UseqModel:
+    ) -> _Y:
         if content_type is None:
             assume_yaml = False
         else:
@@ -79,7 +93,7 @@ class UseqModel(BaseModel):
             try:
                 obj = yaml.safe_load(b)
             except Exception as e:
-                raise ValidationError([ErrorWrapper(e, loc=ROOT_KEY)], cls)
+                raise ValidationError([ErrorWrapper(e, loc=ROOT_KEY)], cls) from e
             return cls.parse_obj(obj)
         return super().parse_raw(
             b,
@@ -91,14 +105,14 @@ class UseqModel(BaseModel):
 
     @classmethod
     def parse_file(
-        cls: Type[UseqModel],
+        cls: Type[_Y],
         path: Union[str, Path],
         *,
         content_type: Optional[str] = None,
         encoding: str = "utf8",
         proto: Optional[str] = None,
         allow_pickle: bool = False,
-    ) -> UseqModel:
+    ) -> _Y:
         if encoding is None:
             assume_yaml = False
         elif content_type:

--- a/useq/_channel.py
+++ b/useq/_channel.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from typing import Any, Callable, Generator, Optional
 
-from pydantic import BaseModel
 from pydantic.types import PositiveFloat, PositiveInt
 
+from ._base_model import FrozenModel
 
-class Channel(BaseModel):
+
+class Channel(FrozenModel):
     config: str
     group: str = "Channel"
     exposure: Optional[PositiveFloat] = None

--- a/useq/_mda_sequence.py
+++ b/useq/_mda_sequence.py
@@ -123,24 +123,6 @@ class MDASequence(UseqModel):
 
         return order
 
-    def add_channel(
-        self,
-        config: str,
-        group: str = "Channel",
-        exposure: int = None,
-        do_stack: bool = False,
-    ) -> None:
-        new = Channel(config=config, group=group, exposure=exposure, do_stack=do_stack)
-        self.channels = tuple(self.channels) + (new,)
-
-    def remove_channel(self, **kwargs: Union[str, int, bool]) -> None:
-        to_pop = [
-            c
-            for c in self.channels
-            if any(getattr(c, k) == v for k, v in kwargs.items())
-        ]
-        self.channels = tuple(i for i in self.channels if i not in to_pop)
-
     def __str__(self) -> str:
         shape = [
             f"n{k.lower()}: {len(list(self.iter_axis(k)))}" for k in self.axis_order

--- a/useq/_position.py
+++ b/useq/_position.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from typing import Any, Callable, Generator, Optional
 
 import numpy as np
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from ._base_model import FrozenModel
 from ._z import AnyZPlan, NoZ
 
 
-class Position(BaseModel):
+class Position(FrozenModel):
     # if None, implies 'do not move this axis'
     x: Optional[float] = None
     y: Optional[float] = None

--- a/useq/_time.py
+++ b/useq/_time.py
@@ -1,9 +1,10 @@
 import datetime
 from typing import Any, Callable, Generator, Iterator, Sequence, Union
 
-from pydantic import BaseModel
 from pydantic.datetime_parse import parse_duration
 from pydantic.types import PositiveInt
+
+from ._base_model import FrozenModel
 
 
 class timedelta(datetime.timedelta):
@@ -18,7 +19,7 @@ class timedelta(datetime.timedelta):
         return parse_duration(v)
 
 
-class TimePlan(BaseModel):
+class TimePlan(FrozenModel):
     # TODO: probably needs to be implemented by engine
     prioritize_duration: bool = False  # or prioritize num frames
 

--- a/useq/_utils.py
+++ b/useq/_utils.py
@@ -1,0 +1,23 @@
+from typing import Iterable, Iterator, Mapping, Tuple, TypeVar, Union
+
+KT = TypeVar("KT")
+VT = TypeVar("VT")
+
+
+class ReadOnlyDict(Mapping[KT, VT]):
+    def __init__(
+        self, data: Union[Mapping[KT, VT], Iterable[Tuple[KT, VT]]] = ()
+    ) -> None:
+        self._data = dict(data)
+
+    def __getitem__(self, key: KT) -> VT:
+        return self._data[key]
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self) -> Iterator[KT]:
+        return iter(self._data)
+
+    def __repr__(self) -> str:
+        return repr(self._data)

--- a/useq/_z.py
+++ b/useq/_z.py
@@ -1,10 +1,11 @@
 from typing import Iterator, List, Sequence, Union
 
 import numpy as np
-from pydantic import BaseModel
+
+from ._base_model import FrozenModel
 
 
-class ZPlan(BaseModel):
+class ZPlan(FrozenModel):
     go_up: bool
 
     def __iter__(self) -> Iterator[float]:  # type: ignore


### PR DESCRIPTION
This effectively makes all instances of MDASequence and MDAEvent frozen after creation.  They can be copied with modifications, but they can't be updated in place.  This is much safer inasmuch as these are objects that might be passed around to consumers (who could mutate state)