### PR TITLE
fix: fix TileRelative and TileFromCorners

### DIFF
--- a/src/useq/_tile.py
+++ b/src/useq/_tile.py
@@ -125,11 +125,11 @@ class TileFromCorners(_TilePlan):
     corner2: Coordinate
 
     def _nrows(self, dx: float) -> int:
-        total_width = abs(self.corner1.x - self.corner2.x)
+        total_width = abs(self.corner1.x - self.corner2.x) + dx
         return math.ceil(total_width / dx)
 
     def _ncols(self, dy: float) -> int:
-        total_height = abs(self.corner1.y - self.corner2.y)
+        total_height = abs(self.corner1.y - self.corner2.y) + dy
         return math.ceil(total_height / dy)
 
     def _offset_x(self, dx: float) -> float:

--- a/src/useq/_tile.py
+++ b/src/useq/_tile.py
@@ -177,9 +177,7 @@ class TileRelative(_TilePlan):
 
     def _offset_y(self, dy: float) -> float:
         return (
-            -((self.rows - 1) * dy) / 2
-            if self.relative_to == RelativeTo.center
-            else 0.0
+            ((self.rows - 1) * dy) / 2 if self.relative_to == RelativeTo.center else 0.0
         )
 
 

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -1,0 +1,62 @@
+from typing import List, Tuple, Union
+
+import pytest
+
+from useq import TileFromCorners, TileRelative
+
+# assuming fov = (1, 1)
+tiles = [
+    (
+        TileRelative(rows=2, cols=2, snake_order=False),
+        [(-0.5, 0.5, 0, 0), (0.5, 0.5, 0, 1), (-0.5, -0.5, 1, 0), (0.5, -0.5, 1, 1)],
+    ),
+    (
+        TileRelative(rows=2, cols=2),
+        [(-0.5, 0.5, 0, 0), (0.5, 0.5, 0, 1), (0.5, -0.5, 1, 1), (-0.5, -0.5, 1, 0)],
+    ),
+    (
+        TileRelative(rows=2, cols=2, relative_to="top_left", snake_order=False),
+        [(0.0, 0.0, 0, 0), (1.0, 0.0, 0, 1), (0.0, -1.0, 1, 0), (1.0, -1.0, 1, 1)],
+    ),
+    (
+        TileRelative(rows=2, cols=2, relative_to="top_left"),
+        [(0.0, 0.0, 0, 0), (1.0, 0.0, 0, 1), (1.0, -1.0, 1, 1), (0.0, -1.0, 1, 0)],
+    ),
+    (
+        TileFromCorners(corner1=(0, 0), corner2=(2, 2), snake_order=False),
+        [
+            (0.0, 0.0, 0, 0),
+            (1.0, 0.0, 0, 1),
+            (2.0, 0.0, 0, 2),
+            (0.0, -1.0, 1, 0),
+            (1.0, -1.0, 1, 1),
+            (2.0, -1.0, 1, 2),
+            (0.0, -2.0, 2, 0),
+            (1.0, -2.0, 2, 1),
+            (2.0, -2.0, 2, 2),
+        ],
+    ),
+    (
+        TileFromCorners(corner1=(0, 0), corner2=(2, 2)),
+        [
+            (0.0, 0.0, 0, 0),
+            (1.0, 0.0, 0, 1),
+            (2.0, 0.0, 0, 2),
+            (2.0, -1.0, 1, 2),
+            (1.0, -1.0, 1, 1),
+            (0.0, -1.0, 1, 0),
+            (0.0, -2.0, 2, 0),
+            (1.0, -2.0, 2, 1),
+            (2.0, -2.0, 2, 2),
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize("tilemode, expectedpos", tiles)
+def test_tiles(
+    tilemode: Union[TileRelative, TileFromCorners], expectedpos: List[Tuple]
+):
+    assert [
+        (i.x, i.y, i.row, i.col) for i in list(tilemode.iter_tiles(1, 1))
+    ] == expectedpos


### PR DESCRIPTION
in this PR:
- fix the  sign in `TileRelative` `_offset_y` method when `RelativeTo` is set to `center`.  If left negative, the grid is not calculated using the starting position as the center one.
- fix `TileFromCorners` so that the `corner` position are considered at the center of the image (and not at the top left corner).
- add specific tests for tiles.