### PR TITLE
feat: add warning on unused keys in valid object

### DIFF
--- a/src/useq/_base_model.py
+++ b/src/useq/_base_model.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import (
     IO,
@@ -39,7 +40,6 @@ class FrozenModel(BaseModel):
         """Validate kwargs for MDASequence."""
         extra_kwargs = set(values) - set(cls.__fields__)
         if extra_kwargs:
-            import warnings
 
             name = getattr(cls, "__name__", "")
             warnings.warn(f"{name} got unknown keyword arguments: {extra_kwargs}")

--- a/src/useq/_base_model.py
+++ b/src/useq/_base_model.py
@@ -5,6 +5,7 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Any,
+    Dict,
     Optional,
     Sequence,
     Tuple,
@@ -13,7 +14,7 @@ from typing import (
     Union,
 )
 
-from pydantic import BaseModel
+from pydantic import BaseModel, root_validator
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
 from pydantic.types import StrBytes
 from pydantic.utils import ROOT_KEY
@@ -30,8 +31,21 @@ _Y = TypeVar("_Y", bound="UseqModel")
 class FrozenModel(BaseModel):
     class Config:
         allow_population_by_field_name = True
-        extra = "ignore"
+        extra = "allow"
         frozen = True
+
+    @root_validator(pre=False, skip_on_failure=True)
+    def _validate_kwargs(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate kwargs for MDASequence."""
+        extra_kwargs = set(values) - set(cls.__fields__)
+        if extra_kwargs:
+            import warnings
+
+            name = getattr(cls, "__name__", "")
+            warnings.warn(f"{name} got unknown keyword arguments: {extra_kwargs}")
+            for k in extra_kwargs:
+                values.pop(k)
+        return values
 
 
 class UseqModel(FrozenModel):

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -137,7 +137,9 @@ class MDASequence(UseqModel):
         sequence with only a few fields changed.  The uid of the new sequence will
         be different from the original
         """
-        kwargs = {k: v for k, v in locals().items() if v is not Undefined}
+        kwargs = {
+            k: v for k, v in locals().items() if v is not Undefined and k != "self"
+        }
         state = self.dict(exclude={"uid"})
         return type(self)(**{**state, **kwargs})
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -279,3 +279,12 @@ def test_hashable(mda1: MDASequence) -> None:
 def test_mda_str_repr(mda1: MDASequence) -> None:
     assert str(mda1)
     assert repr(mda1)
+
+
+def test_mda_warns_extra() -> None:
+    with pytest.warns(UserWarning, match="got unknown keyword arguments"):
+        seq = MDASequence(random_key="random_value")
+    assert not hasattr(seq, "random_key")
+
+    with pytest.warns(UserWarning, match="got unknown keyword arguments"):
+        Position(random_key="random_value")


### PR DESCRIPTION
This PR would add a warning if someone uses an unrecognized keyword argument to any model:

```python
MDASequence(random_key='adsfomsadf')
```

we _could_ use `extra='forbid'`, but that raises an exception, which makes it hard to add new keys in the future without breaking backwards compatibility.  