### PR TITLE
fix: update GridFromCorners with top, left, bottom, right floats

### DIFF
--- a/src/useq/__init__.py
+++ b/src/useq/__init__.py
@@ -1,5 +1,5 @@
 from ._channel import Channel
-from ._grid import AnyGridPlan, GridFromCorners, GridRelative, NoGrid
+from ._grid import AnyGridPlan, GridFromEdges, GridRelative, NoGrid
 from ._mda_event import MDAEvent, PropertyTuple
 from ._mda_sequence import MDASequence
 from ._position import Position
@@ -21,7 +21,7 @@ from ._z import (
 
 __all__ = [
     "AnyGridPlan",
-    "GridFromCorners",
+    "GridFromEdges",
     "GridRelative",
     "NoGrid",
     "Channel",

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -170,21 +170,21 @@ class GridFromEdges(_GridPlan):
     Attributes
     ----------
     top : float
-        y value of the top left bounding coordinate
+        value of the top bounding coordinate
     left : float
-        x value of the top left bounding coordinate
+        value of the left bounding coordinate
     bottom : float
-        y value of the bottom right bounding coordinate
+        value of the bottom bounding coordinate
     right : float
-        x value of the bottom right bounding coordinate
+        value of the right bounding coordinate
 
     Values are considered to be in the center of the image.
     """
 
-    top: float  # top_left y
-    left: float  # top_left x
-    bottom: float  # bottom_right y
-    right: float  # bottom_right x
+    top: float
+    left: float
+    bottom: float
+    right: float
 
     def _nrows(self, dy: float) -> int:
         total_height = abs(self.top - self.bottom) + dy

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -135,11 +135,11 @@ class _GridPlan(FrozenModel):
     def _offset_y(self, dy: float) -> float:
         raise NotImplementedError
 
-    def _nrows(self, dx: float) -> int:
+    def _nrows(self, dy: float) -> int:
         """Return the number of rows, given a grid step size."""
         raise NotImplementedError
 
-    def _ncolumns(self, dy: float) -> int:
+    def _ncolumns(self, dx: float) -> int:
         """Return the number of columns, given a grid step size."""
         raise NotImplementedError
 
@@ -148,8 +148,8 @@ class _GridPlan(FrozenModel):
     ) -> Iterator[GridPosition]:
         """Iterate over all grid positions, given a field of view size."""
         dx, dy = self._step_size(fov_width, fov_height)
-        rows = self._nrows(dx)
-        cols = self._ncolumns(dy)
+        rows = self._nrows(dy)
+        cols = self._ncolumns(dx)
         x0 = self._offset_x(dx)
         y0 = self._offset_y(dy)
         for r, c in _INDEX_GENERATORS[self.mode](rows, cols):
@@ -186,19 +186,19 @@ class GridFromEdges(_GridPlan):
     bottom: float  # bottom_right y
     right: float  # bottom_right x
 
-    def _nrows(self, dx: float) -> int:
-        total_width = abs(self.left - self.right) + dx
-        return math.ceil(total_width / dx)
-
-    def _ncolumns(self, dy: float) -> int:
+    def _nrows(self, dy: float) -> int:
         total_height = abs(self.top - self.bottom) + dy
         return math.ceil(total_height / dy)
 
+    def _ncolumns(self, dx: float) -> int:
+        total_width = abs(self.right - self.left) + dx
+        return math.ceil(total_width / dx)
+
     def _offset_x(self, dx: float) -> float:
-        return abs(self.left - self.right) / 2
+        return min(self.left, self.right)
 
     def _offset_y(self, dy: float) -> float:
-        return abs(self.top - self.bottom) / 2
+        return max(self.top, self.bottom)
 
 
 class GridRelative(_GridPlan):
@@ -224,10 +224,12 @@ class GridRelative(_GridPlan):
     def is_relative(self) -> bool:
         return True
 
-    def _nrows(self, dx: float) -> int:
+    # def _nrows(self, dx: float) -> int:
+    def _nrows(self, dy: float) -> int:
         return self.rows
 
-    def _ncolumns(self, dy: float) -> int:
+    # def _ncolumns(self, dy: float) -> int:
+    def _ncolumns(self, dx: float) -> int:
         return self.columns
 
     def _offset_x(self, dx: float) -> float:

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -89,31 +89,6 @@ _INDEX_GENERATORS: dict[OrderMode, IndexGenerator] = {
 }
 
 
-class Coordinate(FrozenModel):
-    """Defines a position in 2D space.
-
-    Attributes
-    ----------
-    x : float
-        X position in microns.
-    y : float
-        Y position in microns.
-    """
-
-    x: float
-    y: float
-
-    @classmethod
-    def validate(cls, v: Any) -> "Coordinate":
-        if isinstance(v, Coordinate):  # pragma: no cover
-            return v
-        if isinstance(v, dict):
-            return Coordinate(**v)
-        if isinstance(v, (list, tuple)):
-            return Coordinate(x=v[0], y=v[1])
-        raise ValueError(f"Cannot convert to Coordinate: {v}")  # pragma: no cover
-
-
 class GridPosition(NamedTuple):
     x: float
     y: float
@@ -194,30 +169,36 @@ class GridFromCorners(_GridPlan):
 
     Attributes
     ----------
-    corner1 : Coordinate
-        First bounding coordinate (e.g. "top left"). The position is considered
-        to be in the center of the image.
-    corner2 : Coordinate
-        Second bounding coordinate (e.g. "bottom right"). The position is considered
-        to be in the center of the image.
+    top : float
+        y value of the top left bounding coordinate
+    bottom : float
+        y value of the bottom right bounding coordinate
+    left : float
+        x value of the top left bounding coordinate
+    right : float
+        x value of the bottom right bounding coordinate
+
+    Values are considered to be in the center of the image.
     """
 
-    corner1: Coordinate
-    corner2: Coordinate
+    top: float  # top_left y
+    left: float  # top_left x
+    bottom: float  # bottom_right y
+    right: float  # bottom_right x
 
     def _nrows(self, dx: float) -> int:
-        total_width = abs(self.corner1.x - self.corner2.x) + dx
+        total_width = abs(self.left - self.right) + dx
         return math.ceil(total_width / dx)
 
     def _ncolumns(self, dy: float) -> int:
-        total_height = abs(self.corner1.y - self.corner2.y) + dy
+        total_height = abs(self.top - self.bottom) + dy
         return math.ceil(total_height / dy)
 
     def _offset_x(self, dx: float) -> float:
-        return abs(self.corner1.x - self.corner2.x) / 2
+        return abs(self.left - self.right) / 2
 
     def _offset_y(self, dy: float) -> float:
-        return abs(self.corner1.y - self.corner2.y) / 2
+        return abs(self.top - self.bottom) / 2
 
 
 class GridRelative(_GridPlan):

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -224,11 +224,9 @@ class GridRelative(_GridPlan):
     def is_relative(self) -> bool:
         return True
 
-    # def _nrows(self, dx: float) -> int:
     def _nrows(self, dy: float) -> int:
         return self.rows
 
-    # def _ncolumns(self, dy: float) -> int:
     def _ncolumns(self, dx: float) -> int:
         return self.columns
 

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -164,7 +164,7 @@ class _GridPlan(FrozenModel):
         return dx, dy
 
 
-class GridFromCorners(_GridPlan):
+class GridFromEdges(_GridPlan):
     """Define grid positions from two corners.
 
     Attributes
@@ -250,4 +250,4 @@ class NoGrid(_GridPlan):
         return iter([])
 
 
-AnyGridPlan = Union[GridFromCorners, GridRelative, NoGrid]
+AnyGridPlan = Union[GridFromEdges, GridRelative, NoGrid]

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -165,7 +165,7 @@ class _GridPlan(FrozenModel):
 
 
 class GridFromEdges(_GridPlan):
-    """Define grid positions from two corners.
+    """Yield grid positions to cover an area defined by top/left/bottom/right edges.
 
     Attributes
     ----------
@@ -177,8 +177,6 @@ class GridFromEdges(_GridPlan):
         value of the bottom bounding coordinate
     right : float
         value of the right bounding coordinate
-
-    Values are considered to be in the center of the image.
     """
 
     top: float

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -165,18 +165,21 @@ class _GridPlan(FrozenModel):
 
 
 class GridFromEdges(_GridPlan):
-    """Yield grid positions to cover an area defined by top/left/bottom/right edges.
+    """Yield absolute stage positions to cover a bounded area...
+    
+    ...defined by setting the stage coordinates of the top, left,
+    bottom and right edges.
 
     Attributes
     ----------
     top : float
-        value of the top bounding coordinate
+        stage position of the top bounding area
     left : float
-        value of the left bounding coordinate
+        stage position of the left bounding area
     bottom : float
-        value of the bottom bounding coordinate
+        stage position of the bottom bounding area
     right : float
-        value of the right bounding coordinate
+        stage position of the right bounding area
     """
 
     top: float

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -171,10 +171,10 @@ class GridFromCorners(_GridPlan):
     ----------
     top : float
         y value of the top left bounding coordinate
-    bottom : float
-        y value of the bottom right bounding coordinate
     left : float
         x value of the top left bounding coordinate
+    bottom : float
+        y value of the bottom right bounding coordinate
     right : float
         x value of the bottom right bounding coordinate
 

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -167,19 +167,19 @@ class _GridPlan(FrozenModel):
 class GridFromEdges(_GridPlan):
     """Yield absolute stage positions to cover a bounded area...
     
-    ...defined by setting the stage coordinates of the top, left,
+    ...defined by setting the stage coordinates of its top, left,
     bottom and right edges.
 
     Attributes
     ----------
     top : float
-        stage position of the top bounding area
+       top stage position of the bounding area
     left : float
-        stage position of the left bounding area
+        left stage position of the bounding area
     bottom : float
-        stage position of the bottom bounding area
+        bottom stage position of the bounding area
     right : float
-        stage position of the right bounding area
+        right stage position of the bounding area
     """
 
     top: float

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -21,7 +21,7 @@ CHANNEL = "c"
 POSITION = "p"
 Z = "z"
 GRID = "g"
-INDICES = (TIME, POSITION, CHANNEL, Z, GRID)
+INDICES = (TIME, POSITION, GRID, CHANNEL, Z)
 
 Undefined = object()
 
@@ -40,8 +40,8 @@ class MDASequence(UseqModel):
     metadata : dict
         A dictionary of user metadata to be stored with the sequence.
     axis_order : str
-        The order of the axes in the sequence. Must be a permutation of `"tpcz"`. The
-        default is `"tpcz"`.
+        The order of the axes in the sequence. Must be a permutation of `"tpgcz"`. The
+        default is `"tpgcz"`.
     stage_positions : tuple[Position, ...]
         The stage positions to visit. (each with `x`, `y`, `z`, `name`, and `z_plan`,
         all of which are optional).

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -67,7 +67,7 @@ def test_grid_type():
         (0.0, -0.5),
         (-1.0, -0.5),
     ]
-    g2 = GridFromEdges(overlap=0.0, top=1, left=-1, bottom=-1, right=2)
+    g2 = GridFromEdges(top=1, left=-1, bottom=-1, right=2)
     assert [(g.x, g.y) for g in g2.iter_grid_positions(1, 1)] == [
         (-1.0, 1.0),
         (0.0, 1.0),

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,6 +1,6 @@
 import pytest
 
-from useq import GridRelative
+from useq import GridFromEdges, GridRelative
 from useq._grid import OrderMode, _rect_indices, _spiral_indices
 
 EXPECT = {
@@ -55,3 +55,30 @@ def test_position_equality():
     snake_col_pos = set(t5.iter_grid_positions(1, 1))
 
     assert spiral_pos == row_pos == snake_row_pos == col_pos == snake_col_pos
+
+
+def test_grid_type():
+    g1 = GridRelative(rows=2, columns=3)
+    assert [(g.x, g.y) for g in g1.iter_grid_positions(1, 1)] == [
+        (-1.0, 0.5),
+        (0.0, 0.5),
+        (1.0, 0.5),
+        (1.0, -0.5),
+        (0.0, -0.5),
+        (-1.0, -0.5),
+    ]
+    g2 = GridFromEdges(overlap=0.0, top=1, left=-1, bottom=-1, right=2)
+    assert [(g.x, g.y) for g in g2.iter_grid_positions(1, 1)] == [
+        (-1.0, 1.0),
+        (0.0, 1.0),
+        (1.0, 1.0),
+        (2.0, 1.0),
+        (2.0, 0.0),
+        (1.0, 0.0),
+        (0.0, 0.0),
+        (-1.0, 0.0),
+        (-1.0, -1.0),
+        (0.0, -1.0),
+        (1.0, -1.0),
+        (2.0, -1.0),
+    ]

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -23,7 +23,7 @@ from useq import (
     ZRangeAround,
     ZRelativePositions,
 )
-from useq._grid import Coordinate, OrderMode, RelativeTo
+from useq._grid import OrderMode, RelativeTo
 
 _T = List[Tuple[Any, Sequence[float]]]
 
@@ -84,13 +84,8 @@ g_as_dict = [
         [(10.0, 10.0), OrderMode.row_wise_snake, 1, 2, RelativeTo.top_left],
     ),
     (
-        {"overlap": 10.0, "corner1": {"x": 0, "y": 0}, "corner2": {"x": 2, "y": 2}},
-        [
-            (10.0, 10.0),
-            OrderMode.row_wise_snake,
-            Coordinate(x=0, y=0),
-            Coordinate(x=2, y=2),
-        ],
+        {"overlap": 10.0, "top": 0.0, "left": 0.0, "bottom": 2.0, "right": 2.0},
+        [(10.0, 10.0), OrderMode.row_wise_snake, 0.0, 0.0, 2.0, 2.0],
     ),
     ({}, [(0.0, 0.0), OrderMode.row_wise_snake]),
 ]
@@ -101,13 +96,8 @@ g_as_class = [
         [(10.0, 10.0), OrderMode.row_wise_snake, 1, 2, RelativeTo.center],
     ),
     (
-        GridFromCorners(overlap=10.0, corner1=(0, 0), corner2=(2, 2)),
-        [
-            (10.0, 10.0),
-            OrderMode.row_wise_snake,
-            Coordinate(x=0, y=0),
-            Coordinate(x=2, y=2),
-        ],
+        GridFromCorners(overlap=10.0, top=0.0, left=0, bottom=2, right=2),
+        [(10.0, 10.0), OrderMode.row_wise_snake, 0.0, 0.0, 2.0, 2.0],
     ),
     (NoGrid(), [(0.0, 0.0), OrderMode.row_wise_snake]),
 ]

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from useq import (
     Channel,
-    GridFromCorners,
+    GridFromEdges,
     GridRelative,
     MDAEvent,
     MDASequence,
@@ -96,7 +96,7 @@ g_as_class = [
         [(10.0, 10.0), OrderMode.row_wise_snake, 1, 2, RelativeTo.center],
     ),
     (
-        GridFromCorners(overlap=10.0, top=0.0, left=0, bottom=2, right=2),
+        GridFromEdges(overlap=10.0, top=0.0, left=0, bottom=2, right=2),
         [(10.0, 10.0), OrderMode.row_wise_snake, 0.0, 0.0, 2.0, 2.0],
     ),
     (NoGrid(), [(0.0, 0.0), OrderMode.row_wise_snake]),


### PR DESCRIPTION
This PR updates the `GridFromCorners` object. Instead of setting up the grid bounding box using 2 coordinates (`corner1` and `corner2`), the grid is now defined by `top`, `left`, `bottom`, `right` `floats`.