### PR TITLE
fix: fix _check_order method

### DIFF
--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -243,6 +243,7 @@ class MDASequence(UseqModel):
             GRID in order
             and POSITION in order
             and grid_plan is not None
+            and not isinstance(grid_plan, NoGrid)
             and not grid_plan.is_relative
             and len(stage_positions) > 1
         ):

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -242,7 +242,7 @@ class MDASequence(UseqModel):
         if (
             GRID in order
             and POSITION in order
-            and grid_plan
+            and grid_plan is not None
             and not grid_plan.is_relative
             and len(stage_positions) > 1
         ):


### PR DESCRIPTION
This PR fixes an issue in the `MDASequence` `_check_order` methods. It prevents a `grid_plan` to be "validated" with the default for_size (1, 1) when not needed.