### PR TITLE
fix: MDASequence iter_sequence method

### DIFF
--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -406,21 +406,25 @@ def iter_sequence(sequence: MDASequence) -> Iterator[MDAEvent]:
             continue
         # skip if also in position.sequence
         if position and position.sequence:
+            # NOTE: if we ever add more plans, they will need to be explicitly added
+            # https://github.com/pymmcore-plus/useq-schema/pull/85
+
+            # get if sub-sequence has any plan
+            plans = any(
+                (
+                    position.sequence.grid_plan,
+                    position.sequence.z_plan,
+                    position.sequence.time_plan,
+                )
+            )
+            # overwriting the *global* channel index since it is no longer relevant.
+            # if channel IS SPECIFIED in the position.sequence WITH any plan,
+            # we skip otherwise the channel will be acquired twice. Same happens if
+            # the channel IS NOT SPECIFIED but ANY plan is.
             if (
-                # if a position specifies channels, then the *global* channel index
-                # is no longer relevant... so we skip all but the first "global" channel
                 CHANNEL in index
                 and index[CHANNEL] != 0
-                # UNLESS the position specifies any other plan.
-                # NOTE: if we ever add more plans, they will need to be explicitly added
-                # https://github.com/pymmcore-plus/useq-schema/pull/85
-                and not any(
-                    (
-                        position.sequence.grid_plan,
-                        position.sequence.z_plan,
-                        position.sequence.time_plan,
-                    )
-                )
+                and ((position.sequence.channels and plans) or not plans)
             ):
                 continue
             if Z in index and index[Z] != 0 and position.sequence.z_plan:

--- a/tests/test_position_sequence.py
+++ b/tests/test_position_sequence.py
@@ -676,3 +676,29 @@ def test_channels_and_pos_z_grid_and_time_plan():
 
     chs = {i.channel.config for i in mda}
     assert chs == {"Cy5", "FITC"}
+
+
+def test_sub_channels_and_any_plan():
+    # test that only specified sub-channels are acquired for each z plan
+    mda = MDASequence(
+        axis_order="tpgcz",
+        channels=[
+            {"config": "Cy5", "exposure": 10},
+            {"config": "FITC", "exposure": 10},
+        ],
+        stage_positions=[
+            {
+                "x": 0,
+                "y": 0,
+                "z": 0,
+                "sequence": {
+                    "channels": ["DAPI"],
+                    "z_plan": {"range": 2, "step": 1},
+                },
+            }
+        ],
+    )
+
+    chs = {i.channel.config for i in mda}
+    assert chs == {"DAPI"}
+    assert len(list(mda.iter_events())) == 3

--- a/tests/test_position_sequence.py
+++ b/tests/test_position_sequence.py
@@ -682,20 +682,9 @@ def test_sub_channels_and_any_plan():
     # test that only specified sub-channels are acquired for each z plan
     mda = MDASequence(
         axis_order="tpgcz",
-        channels=[
-            {"config": "Cy5", "exposure": 10},
-            {"config": "FITC", "exposure": 10},
-        ],
+        channels=["Cy5", "FITC"],
         stage_positions=[
-            {
-                "x": 0,
-                "y": 0,
-                "z": 0,
-                "sequence": {
-                    "channels": ["DAPI"],
-                    "z_plan": {"range": 2, "step": 1},
-                },
-            }
+            {"sequence": {"channels": ["DAPI"], "z_plan": {"range": 2, "step": 1}}}
         ],
     )
 


### PR DESCRIPTION
This PR fix a bug in the `MDASequence` `iter_sequence` method.

Currently, if we iter through a `MDASequence` where we specify `channels` (> 1) in the main sequence and `channel(s) + any plan` in the sub-sequence like the one below...

```py
mda = MDASequence(
      axis_order="tpgcz",
      channels=["Cy5", "FITC"],
      stage_positions=[{"sequence": {"channels": ["DAPI"], "z_plan": {"range": 2, "step": 1}}}]
)
```
...we duplicate the number of events (duplication depends on the number of channels that are specified in the main sequence.). This is the current result:

```py
index: {'p': 0, 'c': 0, 'z': 0}  channel: DAPI
index: {'p': 0, 'c': 0, 'z': 1}  channel: DAPI
index: {'p': 0, 'c': 0, 'z': 2}  channel: DAPI
index: {'p': 0, 'c': 0, 'z': 0}  channel: DAPI
index: {'p': 0, 'c': 0, 'z': 1}  channel: DAPI
index: {'p': 0, 'c': 0, 'z': 2}  channel: DAPI
```

with this fix, we make sure that the the sequence is not executed n times.
```py
index: {'p': 0, 'c': 0, 'z': 0}  channel: DAPI
index: {'p': 0, 'c': 0, 'z': 1}  channel: DAPI
index: {'p': 0, 'c': 0, 'z': 2}  channel: DAPI
```