### PR TITLE
fix: fix inherit sequence autofocus + add tests

### DIFF
--- a/tests/test_autofocus.py
+++ b/tests/test_autofocus.py
@@ -55,6 +55,9 @@ AF_TESTS: list[tuple[MDASequence, tuple[str, ...], Iterable[int]]] = [
     (TWO_CH_SUBPAF_C.replace(z_plan=ZRANGE2, grid_plan=GRID_PLAN), ("c",), range(0, 29, 4)),
     (TWO_CH.replace(stage_positions=[ZPOS_30, useq.Position(z=10, sequence=MDASequence(autofocus_plan=AF_C, grid_plan=GRID_PLAN))]), (), (2, 5)),
     (TWO_CH.replace(stage_positions=[SUB_P_AF_C, useq.Position(z=10, sequence=MDASequence(autofocus_plan=AF_G, grid_plan=GRID_PLAN))]), (), range(0, 11, 2)),
+    (TWO_CH.replace(stage_positions=[ZPOS_200, useq.Position(z=10, sequence=MDASequence(z_plan=ZRANGE2))]), ("z",), range(2, 13, 2)),
+    (TWO_CH.replace(stage_positions=[ZPOS_200, useq.Position(z=10, sequence=MDASequence(z_plan=ZRANGE2))]), ("c",), (0, 2, 4, 8)),
+    (TWO_CH.replace(stage_positions=[ZPOS_200, useq.Position(z=10, sequence=MDASequence(z_plan=ZRANGE2))]), (), ()),
 ]
 # fmt: on
 


### PR DESCRIPTION
I found an `autofocus_plan` bug in the `MDASequence` `iter_sequence` method and this PR is a possible fix (also related to #97 ).

If we have a `MDASequence` with a position sub-sequence (like the one below)  where the `autofocus_plan` is *only* specified in the main sequence, the `autofocus_plan` should be also inherited by the position sub-sequence. However at the moment this does not happen.

```py
mda = MDASequence(
    channels=["DAPI", "FITC"],
    stage_positions=[(1, 2, 3),{"z": 10, "sequence":{"z_plan": {"range": 2, "step": 1}}}],
    autofocus_plan={"autofocus_device_name": "Z", "autofocus_motor_offset": 40, "axes": ("z",)}
)
```

by printing index and action type
```
for e in mda:
    print(e.index, e.action.type
```
we get
```
{'p': 0, 'c': 0} acquire_image
{'p': 0, 'c': 1} acquire_image
{'p': 1, 'c': 0, 'z': 0} acquire_image
{'p': 1, 'c': 0, 'z': 1} acquire_image
{'p': 1, 'c': 0, 'z': 2} acquire_image
{'p': 1, 'c': 1, 'z': 0} acquire_image
{'p': 1, 'c': 1, 'z': 1} acquire_image
{'p': 1, 'c': 1, 'z': 2} acquire_image
```
indicating that the auto shutter is never used. While we should instead autofocus performed at every z planes like so
```
{'p': 0, 'c': 0} acquire_image
{'p': 0, 'c': 1} acquire_image
{'p': 1, 'c': 0, 'z': 0} hardware_autofocus
{'p': 1, 'c': 0, 'z': 0} acquire_image
{'p': 1, 'c': 0, 'z': 1} hardware_autofocus
{'p': 1, 'c': 0, 'z': 1} acquire_image
{'p': 1, 'c': 0, 'z': 2} hardware_autofocus
{'p': 1, 'c': 0, 'z': 2} acquire_image
{'p': 1, 'c': 1, 'z': 0} hardware_autofocus
{'p': 1, 'c': 1, 'z': 0} acquire_image
{'p': 1, 'c': 1, 'z': 1} hardware_autofocus
{'p': 1, 'c': 1, 'z': 1} acquire_image
{'p': 1, 'c': 1, 'z': 2} hardware_autofocus
{'p': 1, 'c': 1, 'z': 2} acquire_image
```
