### PR TITLE
fix: KeyError fix in MDASequence _should_skip method

### DIFF
--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -565,7 +565,7 @@ def _should_skip(
             return True
 
         # only acquire on the middle plane:
-        if not channel.do_stack and index[Z] != len(z_plan) // 2:
+        if not channel.do_stack and z_plan and index[Z] != len(z_plan) // 2:
             return True
 
     if not position or not position.sequence:

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -325,3 +325,8 @@ def test_mda_warns_extra() -> None:
 
     with pytest.warns(UserWarning, match="got unknown keyword arguments"):
         Position(random_key="random_value")
+
+
+def test_skip_channel_do_stack_no_zplan():
+    mda = MDASequence(channels=[{"config": "DAPI", "do_stack": False}])
+    assert len(list(mda)) == 1


### PR DESCRIPTION
this PR fixes a bug  in the `MDASequence` `_should_skip` method.

if we run this
```py
mda = MDASequence(channels=[{"config": "DAPI", "do_stack": False}])
    assert len(list(mda)) == 1
```
we get a "z" KeyError because in the `_should_skip` method we don't make sure to also check for a `z_plan`
```py
# only acquire on the middle plane:
if not channel.do_stack and index[Z] != len(z_plan) // 2:
    return True
```
note: just switching from `index[Z]` to `index.get(Z)` does not work because the event will be skipped even when it shouldn't be.