### PR TITLE
refactor: move replace to FrozenModel

### DIFF
--- a/src/useq/_base_model.py
+++ b/src/useq/_base_model.py
@@ -17,15 +17,17 @@ from typing import (
 
 from pydantic import BaseModel, root_validator
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
-from pydantic.types import StrBytes
 from pydantic.utils import ROOT_KEY
 
 if TYPE_CHECKING:
+    from pydantic.types import StrBytes
+
     ReprArgs = Sequence[Tuple[Optional[str], Any]]
 
 
 __all__ = ["UseqModel", "FrozenModel"]
 
+_T = TypeVar("_T", bound="FrozenModel")
 _Y = TypeVar("_Y", bound="UseqModel")
 
 
@@ -47,6 +49,20 @@ class FrozenModel(BaseModel):
             for k in extra_kwargs:
                 values.pop(k)
         return values
+
+    def replace(self: _T, **kwargs: Any) -> _T:
+        """Return a new instance replacing specified kwargs with new values.
+
+        This model is immutable, so this method is useful for creating a new
+        sequence with only a few fields changed.  The uid of the new sequence will
+        be different from the original.
+
+        The difference between this and `self.copy(update={...})` is that this method
+        will perform validation and casting on the new values, whereas `copy` assumes
+        that all objects are valid and will not perform any validation or casting.
+        """
+        state = self.dict(exclude={"uid"})
+        return type(self)(**{**state, **kwargs})
 
 
 class UseqModel(FrozenModel):

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -1,17 +1,7 @@
 from __future__ import annotations
 
 from itertools import product
-from typing import (
-    Any,
-    Dict,
-    Iterator,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    cast,
-    no_type_check,
-)
+from typing import Any, Dict, Iterator, Optional, Sequence, Tuple, Union, cast
 from uuid import UUID, uuid4
 from warnings import warn
 
@@ -135,30 +125,6 @@ class MDASequence(UseqModel):
         This is used to calculate the number of positions in a grid plan.
         """
         self._fov_size = fov_size
-
-    @no_type_check
-    def replace(
-        self,
-        metadata: Dict[str, Any] = Undefined,
-        axis_order: str = Undefined,
-        stage_positions: Tuple[Position, ...] = Undefined,
-        grid_plan: AnyGridPlan = Undefined,
-        channels: Tuple[Channel, ...] = Undefined,
-        time_plan: AnyTimePlan = Undefined,
-        z_plan: AnyZPlan = Undefined,
-        autofocus_plan: AnyAutofocusPlan = Undefined,
-    ) -> MDASequence:
-        """Return a new `MDAsequence` replacing specified kwargs with new values.
-
-        MDASequences are immutable, so this method is useful for creating a new
-        sequence with only a few fields changed.  The uid of the new sequence will
-        be different from the original.
-        """
-        kwargs = {
-            k: v for k, v in locals().items() if v is not Undefined and k != "self"
-        }
-        state = self.dict(exclude={"uid"})
-        return type(self)(**{**state, **kwargs})
 
     def __hash__(self) -> int:
         return hash(self.uid)


### PR DESCRIPTION
this moves the `replace` method to the frozen base model, and removes the kwargs from the signature