### PR TITLE
feat: add ci tests for pymmcore_widgets

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -102,7 +102,7 @@ jobs:
         run: mmcore install
 
       - name: Test
-        run: pytest -v --color=yes
+        run: pytest -v --color=yes -W ignore
         working-directory: pymmcore-widgets-from-github
 
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e pymmcore-widgets-from-github["test, image, pyqt6"]
-          pip install -e .[test]
+          pip install -e .
 
       - name: Install Micro-Manager
         run: mmcore install

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e pymmcore-widgets-from-github["test, image, pyqt6"]
+          pip install -e pymmcore-widgets-from-github[test,image,pyqt6]
           pip install -e .[test]
 
       - name: Install Micro-Manager

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -96,7 +96,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e pymmcore-widgets-from-github["test, image, pyqt6"]
-          pip install -e .
 
       - name: Install Micro-Manager
         run: mmcore install

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -77,6 +77,34 @@ jobs:
         run: pytest -v --color=yes
         working-directory: pymmcore-plus-from-github
 
+  test_pymmcore_widgets:
+    name: Test pymmcore-widgets
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: pymmcore-plus/pymmcore-widgets
+          path: pymmcore-widgets-from-github
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e pymmcore-widgets-from-github[test, image, pyqt6]
+          pip install -e .[test]
+
+      - name: Install Micro-Manager
+        run: mmcore install
+
+      - name: Test
+        run: pytest -v --color=yes
+        working-directory: pymmcore-widgets-from-github
+
 
   deploy:
     needs: test

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -96,6 +96,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e pymmcore-widgets-from-github["test, image, pyqt6"]
+          pip install -e .[test]
 
       - name: Install Micro-Manager
         run: mmcore install

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e pymmcore-widgets-from-github[test, image, pyqt6]
+          pip install -e pymmcore-widgets-from-github["test, image, pyqt6"]
           pip install -e .[test]
 
       - name: Install Micro-Manager


### PR DESCRIPTION
failing until the `pymmcore-widgets` version without `NoX` plans is released.