### PR TITLE
feat: add `keep_shutter_open` to MDAEvent

### DIFF
--- a/src/useq/_mda_event.py
+++ b/src/useq/_mda_event.py
@@ -122,6 +122,9 @@ class MDAEvent(UseqModel):
     keep_shutter_open : bool
         If True, the illumination shutter should be left open after the event has
         been executed, otherwise it should be closed. By default, `False`."
+        This is useful when the sequence of events being executed use the same
+        illumination scheme (such as a z-stack in a single channel), and closing and
+        opening the shutter between events would be slow.
     """
 
     index: ReadOnlyDict[str, int] = Field(default_factory=ReadOnlyDict)

--- a/src/useq/_mda_event.py
+++ b/src/useq/_mda_event.py
@@ -119,6 +119,9 @@ class MDAEvent(UseqModel):
         The action to perform for this event.  By default, [`useq.AcquireImage`][].
         Example of another action is [`useq.HardwareAutofocus`][] which could be used
         to perform a hardware autofocus.
+    keep_shutter_open : bool
+        If True, the illumination shutter should be left open after the event has
+        been executed, otherwise it should be closed. By default, `False`."
     """
 
     index: ReadOnlyDict[str, int] = Field(default_factory=ReadOnlyDict)
@@ -133,6 +136,7 @@ class MDAEvent(UseqModel):
     properties: Optional[List[PropertyTuple]] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
     action: Action = Field(default_factory=AcquireImage)
+    keep_shutter_open: bool = False
 
     # action
     # keep shutter open between channels/steps


### PR DESCRIPTION
This simply adds the `keep_shutter_open` field to the MDAEvent object, so that downstream libraries can begin to play with it.  #97 will continue to implement the declarative logic for adding this to the MDASequence