### PR TITLE
fix: change action type hint on MDAEvent 

### DIFF
--- a/src/useq/_actions.py
+++ b/src/useq/_actions.py
@@ -58,4 +58,4 @@ class HardwareAutofocus(Action):
     max_retries: int = 3
 
 
-AnyAction = Union[AcquireImage, HardwareAutofocus]
+AnyAction = Union[HardwareAutofocus, AcquireImage]

--- a/src/useq/_actions.py
+++ b/src/useq/_actions.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from typing_extensions import Literal
 
 from useq._base_model import FrozenModel
@@ -54,3 +56,6 @@ class HardwareAutofocus(Action):
     autofocus_device_name: str
     autofocus_motor_offset: float
     max_retries: int = 3
+
+
+AnyAction = Union[AcquireImage, HardwareAutofocus]

--- a/src/useq/_mda_event.py
+++ b/src/useq/_mda_event.py
@@ -15,7 +15,7 @@ from typing import (
 
 from pydantic import Field, validator
 
-from useq._actions import AcquireImage, Action
+from useq._actions import AcquireImage, AnyAction
 from useq._base_model import UseqModel
 from useq._utils import ReadOnlyDict
 
@@ -138,7 +138,7 @@ class MDAEvent(UseqModel):
     sequence: Optional[MDASequence] = Field(default=None, repr=False)
     properties: Optional[List[PropertyTuple]] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
-    action: Action = Field(default_factory=AcquireImage)
+    action: AnyAction = Field(default_factory=AcquireImage)
     keep_shutter_open: bool = False
 
     # action

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -321,3 +321,8 @@ def test_mda_warns_extra() -> None:
 def test_skip_channel_do_stack_no_zplan():
     mda = MDASequence(channels=[{"config": "DAPI", "do_stack": False}])
     assert len(list(mda)) == 1
+
+
+def test_event_action_union() -> None:
+    # test that action unions work
+    MDAEvent(action={"autofocus_device_name": "Z", "autofocus_motor_offset": 25})


### PR DESCRIPTION
cc @fdrgsp, 
I realized we do actually need to use Union types on MDAEvent.action.

this fixes it