### PR TITLE
docs: update units of exposure in docstring to ms

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ YAML (or JSON) file, and then load that file into your acquisition engine.
 
 For example, the following file defines an experiment with:
 
-- 3 channels (`DAPI`, `FITC`, and `Cy5`), specifying exposure times for each channel
+- 3 channels (`DAPI`, `FITC`, and `Cy5`), specifying exposure times in ms for each channel
 - a two-phase time-lapse: 3 frames in the first phase, followed by a frame every 10 seconds
 for 40 minutes
 - a Z-stack at each timepoint, with a range of 4 microns and a step size of 0.5 micron

--- a/src/useq/_channel.py
+++ b/src/useq/_channel.py
@@ -20,7 +20,7 @@ class Channel(FrozenModel):
         Optional name of the group to which this channel belongs. By default,
         `"Channel"`.
     exposure : float | None
-        Exposure time in seconds. Must be positive.  If not provided, implies use
+        Exposure time in milliseconds. Must be positive.  If not provided, implies use
         current exposure time. By default, `None`.
     do_stack : bool
         If `True`, instructs engine to include this channel in any Z stacks being

--- a/src/useq/_mda_event.py
+++ b/src/useq/_mda_event.py
@@ -88,8 +88,8 @@ class MDAEvent(UseqModel):
         channel, (e.g. `"488nm"`, `"DAPI"`, `"FITC"`).  `group` is the name of the group
         to which this channel belongs. By default, `"Channel"`.
     exposure : float | None
-        Exposure time in seconds. If not provided, implies use current exposure time.
-        By default, `None`.
+        Exposure time in milliseconds. If not provided, implies use current exposure
+        time. By default, `None`.
     min_start_time : float | None
         Minimum start time of this event, in seconds.  If provided, the engine will
         pause until this time has elapsed (relative to the start of the sequence)


### PR DESCRIPTION
We've been treating exposure everywhere (in pymmcore-plus) as if it's in milliseconds.  `core.setExposure` assumes milliseconds.  So this changes the docstring accordingly.  it's a "breaking" change but I doubt that anyone besides pymmcore plus  has been consuming this yet