### PR TITLE
feat: add `keep_shutter_open_across` to MDASequence

### DIFF
--- a/src/useq/_iter_sequence.py
+++ b/src/useq/_iter_sequence.py
@@ -88,7 +88,7 @@ def iter_sequence(sequence: MDASequence) -> Iterator[MDAEvent]:
         return
 
     it = _iter_sequence(sequence)
-    if (this_e := next(it, None)) is None:
+    if (this_e := next(it, None)) is None:  # pragma: no cover
         return
 
     for next_e in it:

--- a/src/useq/_iter_sequence.py
+++ b/src/useq/_iter_sequence.py
@@ -58,13 +58,7 @@ def _used_axes(seq: MDASequence) -> str:
     return "".join(k for k in seq.axis_order if _sizes(seq)[k])
 
 
-def iter_sequence(
-    sequence: MDASequence,
-    *,
-    base_event_kwargs: MDAEventDict | None = None,
-    event_kwarg_overrides: MDAEventDict | None = None,
-    position_offsets: PositionDict | None = None,
-) -> Iterator[MDAEvent]:
+def iter_sequence(sequence: MDASequence) -> Iterator[MDAEvent]:
     """Iterate over all events in the MDA sequence.'.
 
     !!! note
@@ -78,6 +72,53 @@ def iter_sequence(
     The is the most "logic heavy" part of `useq-schema` (the rest of which is
     almost entirely declarative).  This iterator is useful for consuming `MDASequence`
     objects in a python runtime, but it isn't considered a "core" part of the schema.
+
+    Parameters
+    ----------
+    sequence : MDASequence
+        The sequence to iterate over.
+
+    Yields
+    ------
+    MDAEvent
+        Each event in the MDA sequence.
+    """
+    if not (keep_shutter_open_axes := sequence.keep_shutter_open_across):
+        yield from _iter_sequence(sequence)
+        return
+
+    it = _iter_sequence(sequence)
+    if (this_e := next(it, None)) is None:
+        return
+
+    for next_e in it:
+        # set `keep_shutter_open` to `True` if and only if ALL axes whose index
+        # changes betwee this_event and next_event are in `keep_shutter_open_axes`
+        if all(
+            axis in keep_shutter_open_axes
+            for axis, idx in this_e.index.items()
+            if idx != next_e.index[axis]
+        ):
+            this_e = this_e.copy(update={"keep_shutter_open": True})
+        yield this_e
+        this_e = next_e
+    yield this_e
+
+
+def _iter_sequence(
+    sequence: MDASequence,
+    *,
+    base_event_kwargs: MDAEventDict | None = None,
+    event_kwarg_overrides: MDAEventDict | None = None,
+    position_offsets: PositionDict | None = None,
+) -> Iterator[MDAEvent]:
+    """Helper function for `iter_sequence`.
+
+    We put most of the logic into this sub-function so that `iter_sequence` can
+    easily modify the resulting sequence of events (e.g. to peek at the next event
+    before yielding the current one).
+
+    It also keeps the sub-sequence iteration kwargs out of the public API.
 
     Parameters
     ----------
@@ -166,7 +207,7 @@ def iter_sequence(
                     sub_seq = sub_seq.copy(update={"autofocus_plan": autofocus_plan})
 
                 # recurse into the sub-sequence
-                yield from iter_sequence(
+                yield from _iter_sequence(
                     sub_seq,
                     base_event_kwargs=event_kwargs.copy(),
                     event_kwarg_overrides=pos_overrides,

--- a/src/useq/_iter_sequence.py
+++ b/src/useq/_iter_sequence.py
@@ -187,6 +187,9 @@ def iter_sequence(
         yield event
 
 
+# ###################### Helper functions ######################
+
+
 def _position_offsets(
     position: Position, event_kwargs: MDAEventDict
 ) -> tuple[MDAEventDict, PositionDict]:

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -201,6 +201,15 @@ class MDASequence(UseqModel):
                 grid_plan=values.get("grid_plan"),
                 autofocus_plan=values.get("autofocus_plan"),
             )
+        if "stage_positions" in values:
+            for p in values["stage_positions"]:
+                if hasattr(p, "sequence") and getattr(
+                    p.sequence, "keep_shutter_open_across", None
+                ):  # pragma: no cover
+                    raise ValueError(
+                        "keep_shutter_open_across cannot currently be set on a "
+                        "Position sequence"
+                    )
         return values
 
     def __eq__(self, other: Any) -> bool:
@@ -273,7 +282,7 @@ class MDASequence(UseqModel):
             )
         ):
             raise ValueError(
-                "Currently, a Position sequence cannot have multiple stage positions!"
+                "Currently, a Position sequence cannot have multiple stage positions."
             )
 
         # Cannot use autofocus plan with absolute z_plan

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -61,15 +61,13 @@ class MDASequence(UseqModel):
         generated, do not set.
     autofocus_plan : AxesBasedAF | None
         The hardware autofocus plan to follow. One of `AxesBasedAF` or `None`.
-    keep_shutter_open_across: tuple[str, ...]
-        A tuple of axes across which the illumination shutter should be kept open.
-        Resulting events will have `keep_shutter_open` set to `True` if and only if the
-        all axes changing are in this tuple. For example, if
-        `keep_shutter_open_across=('z',)`, then the shutter will be kept open between
-        events axes {'t': 0, 'z: 0} and {'t': 0, 'z': 1}, but not between {'t': 0, 'z':
-        0} and {'t': 1, 'z': 0}. Currently, this cannot contain `'c'` (an exception will
-        be raised if it does). If you have an application where you need to keep the
-        shutter open across channels, please open an issue.
+    keep_shutter_open_across : tuple[str, ...]
+        A tuple of axes `str` across which the illumination shutter should be kept open.
+        Resulting events will have `keep_shutter_open` set to `True` if and only if
+        ALL axes whose indices are changing are in this tuple. For example, if
+        `keep_shutter_open_across=('z',)`, then the shutter would be kept open between
+        events axes {'t': 0, 'z: 0} and {'t': 0, 'z': 1}, but not between
+        {'t': 0, 'z': 0} and {'t': 1, 'z': 0}.
 
     Examples
     --------
@@ -152,6 +150,17 @@ class MDASequence(UseqModel):
     @validator("z_plan", pre=True)
     def _validate_zplan(cls, v: Any) -> Optional[dict]:
         return v or None
+
+    @validator("keep_shutter_open_across", pre=True)
+    def _validate_keep_shutter_open_across(cls, v: tuple[str, ...]) -> tuple[str, ...]:
+        try:
+            v = tuple(v)
+        except (TypeError, ValueError):  # pragma: no cover
+            raise ValueError(
+                f"keep_shutter_open_across must be string or a sequence of strings, "
+                f"got {type(v)}"
+            ) from None
+        return v
 
     @validator("time_plan", pre=True)
     def _validate_time_plan(cls, v: Any) -> Optional[dict]:

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -61,6 +61,15 @@ class MDASequence(UseqModel):
         generated, do not set.
     autofocus_plan : AxesBasedAF | None
         The hardware autofocus plan to follow. One of `AxesBasedAF` or `None`.
+    keep_shutter_open_across: tuple[str, ...]
+        A tuple of axes across which the illumination shutter should be kept open.
+        Resulting events will have `keep_shutter_open` set to `True` if and only if the
+        all axes changing are in this tuple. For example, if
+        `keep_shutter_open_across=('z',)`, then the shutter will be kept open between
+        events axes {'t': 0, 'z: 0} and {'t': 0, 'z': 1}, but not between {'t': 0, 'z':
+        0} and {'t': 1, 'z': 0}. Currently, this cannot contain `'c'` (an exception will
+        be raised if it does). If you have an application where you need to keep the
+        shutter open across channels, please open an issue.
 
     Examples
     --------
@@ -105,6 +114,7 @@ class MDASequence(UseqModel):
     time_plan: Optional[AnyTimePlan] = None
     z_plan: Optional[AnyZPlan] = None
     autofocus_plan: Optional[AnyAutofocusPlan] = None
+    keep_shutter_open_across: Tuple[str, ...] = Field(default_factory=tuple)
 
     _uid: UUID = PrivateAttr(default_factory=uuid4)
     _sizes: Optional[Dict[str, int]] = PrivateAttr(default=None)

--- a/tests/fixtures/mda.json
+++ b/tests/fixtures/mda.json
@@ -48,6 +48,7 @@
     "relative_to": "center",
     "rows": 2
   },
+  "keep_shutter_open_across": [],
   "metadata": {
     "some info": "something"
   },
@@ -77,6 +78,7 @@
           "relative_to": "center",
           "rows": 2
         },
+        "keep_shutter_open_across": [],
         "metadata": {},
         "stage_positions": [],
         "time_plan": null,

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -385,20 +385,14 @@ def test_keep_shutter_open() -> None:
         is_last_zt = bool(event.index["t"] == 1 and event.index["z"] == 1)
         assert event.keep_shutter_open != is_last_zt
 
-    # testing keep shutter open in sub-sequence
+    # even though c is the last axis, and comes after g, because the grid happens
+    # on a subsequence shutter will be open across the grid for each position
+    subseq = MDASequence(grid_plan=GridRelative(rows=2, columns=2))
     mda5 = MDASequence(
         axis_order="pgc",
         channels=["DAPI", "FITC"],
-        stage_positions=[
-            {
-                "x": 0,
-                "y": 0,
-                "sequence": MDASequence(
-                    grid_plan=GridRelative(overlap=10, rows=2, columns=2)
-                ),
-            }
-        ],
+        stage_positions=[Position(sequence=subseq)],
         keep_shutter_open_across="g",
     )
     for event in mda5:
-        assert event.keep_shutter_open != bool(event.index["g"] == 3)
+        assert event.keep_shutter_open != (event.index["g"] == 3)

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -384,3 +384,21 @@ def test_keep_shutter_open() -> None:
     for event in mda4:
         is_last_zt = bool(event.index["t"] == 1 and event.index["z"] == 1)
         assert event.keep_shutter_open != is_last_zt
+
+    # testing keep shutter open in sub-sequence
+    mda5 = MDASequence(
+        axis_order="pgc",
+        channels=["DAPI", "FITC"],
+        stage_positions=[
+            {
+                "x": 0,
+                "y": 0,
+                "sequence": MDASequence(
+                    grid_plan=GridRelative(overlap=10, rows=2, columns=2)
+                ),
+            }
+        ],
+        keep_shutter_open_across="g",
+    )
+    for event in mda5:
+        assert event.keep_shutter_open != bool(event.index["g"] == 3)


### PR DESCRIPTION
This is alternative to #97, that adds a `keep_shutter_open` logic to the MDA sequence.  The logic is described in the docstring:

> A tuple of axes `str` across which the illumination shutter should be kept open.
        Resulting events will have `keep_shutter_open` set to `True` if and only if
        ALL axes whose indices are changing are in this tuple. For example, if
        `keep_shutter_open_across=('z',)`, then the shutter would be kept open between
        events axes {'t': 0, 'z: 0} and {'t': 0, 'z': 1}, but not between
        {'t': 0, 'z': 0} and {'t': 1, 'z': 0}.

closes #97 
closes #3

sidenote: this also opens up a possibility for a generalization of both this and autofocus plan, which would be general functions that take in the current event and (optionally) the upcoming event, and return either a modified current event, a new event or sequence of events to insert, or block yielding of the current event  