### PR TITLE
build: use pydantic-compat library

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,4 +36,5 @@ repos:
         additional_dependencies:
           - types-PyYAML
           - pydantic>=2
+          - pydantic-compat
         files: "^src/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = ["pydantic >=1.7", "numpy"]
+dependencies = ["pydantic >=1.7", "numpy", "pydantic-compat >=0.0.1"]
 
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies

--- a/src/useq/__init__.py
+++ b/src/useq/__init__.py
@@ -45,8 +45,6 @@ __all__ = [
     "ZTopBottom",
 ]
 
-from useq._pydantic_compat import model_rebuild
 
-model_rebuild(MDAEvent, MDASequence=MDASequence)
-model_rebuild(Position, MDASequence=MDASequence)
-del model_rebuild
+MDAEvent.model_rebuild(MDASequence=MDASequence)
+Position.model_rebuild(MDASequence=MDASequence)

--- a/src/useq/_base_model.py
+++ b/src/useq/_base_model.py
@@ -18,8 +18,9 @@ from typing import (
 
 import numpy as np
 from pydantic import BaseModel
+from pydantic_compat import PydanticCompatMixin
 
-from useq._pydantic_compat import PYDANTIC2, model_dump, model_fields
+from useq._pydantic_compat import PYDANTIC2
 
 if TYPE_CHECKING:
     ReprArgs = Sequence[Tuple[Optional[str], Any]]
@@ -31,7 +32,7 @@ _T = TypeVar("_T", bound="FrozenModel")
 _Y = TypeVar("_Y", bound="UseqModel")
 
 
-class FrozenModel(BaseModel):
+class FrozenModel(PydanticCompatMixin, BaseModel):
     if PYDANTIC2:
         model_config = {
             "populate_by_name": True,
@@ -58,49 +59,8 @@ class FrozenModel(BaseModel):
         will perform validation and casting on the new values, whereas `copy` assumes
         that all objects are valid and will not perform any validation or casting.
         """
-        state = model_dump(self, exclude={"uid"})
+        state = self.model_dump(exclude={"uid"})
         return type(self)(**{**state, **kwargs})
-
-    if PYDANTIC2:
-        # retain pydantic1's json method
-        def json(
-            self,
-            *,
-            indent: int | None = None,  # type: ignore
-            include: IncEx = None,
-            exclude: IncEx = None,  # type: ignore
-            by_alias: bool = False,
-            exclude_unset: bool = False,
-            exclude_defaults: bool = False,
-            exclude_none: bool = False,  # type: ignore
-            round_trip: bool = False,
-            warnings: bool = True,
-        ) -> str:
-            return super().model_dump_json(
-                indent=indent,
-                include=include,
-                exclude=exclude,
-                by_alias=by_alias,
-                exclude_unset=exclude_unset,
-                exclude_defaults=exclude_defaults,
-                exclude_none=exclude_none,
-                round_trip=round_trip,
-                warnings=warnings,
-            )
-
-        # we let this one be deprecated
-        # def dict()
-
-    elif not TYPE_CHECKING:
-        # Backport pydantic2 methods so that useq-0.1.0 can be used with pydantic1
-
-        def model_dump_json(self, **kwargs: Any) -> str:
-            """Backport of pydantic2's model_dump_json method."""
-            return self.json(**kwargs)
-
-        def model_dump(self, **kwargs: Any) -> dict[str, Any]:
-            """Backport of pydantic2's model_dump_json method."""
-            return self.dict(**kwargs)
 
 
 class UseqModel(FrozenModel):
@@ -109,12 +69,12 @@ class UseqModel(FrozenModel):
         return [
             (k, val)
             for k, val in super().__repr_args__()
-            if k in model_fields(self)
+            if k in self.model_fields
             and val
             != (
                 factory()
-                if (factory := model_fields(self)[k].default_factory) is not None
-                else model_fields(self)[k].default
+                if (factory := self.model_fields[k].default_factory) is not None
+                else self.model_fields[k].default
             )
         ]
 
@@ -133,7 +93,7 @@ class UseqModel(FrozenModel):
         else:  # pragma: no cover
             raise ValueError(f"Unknown file type: {path.suffix}")
 
-        return cls.model_validate(obj) if PYDANTIC2 else cls.parse_obj(obj)
+        return cls.model_validate(obj)
 
     @classmethod
     def parse_file(cls: Type[_Y], path: Union[str, Path], **kwargs: Any) -> _Y:
@@ -180,8 +140,7 @@ class UseqModel(FrozenModel):
             np.floating, lambda dumper, d: dumper.represent_float(float(d))
         )
 
-        data = model_dump(
-            self,
+        data = self.model_dump(
             include=include,
             exclude=exclude,
             by_alias=by_alias,

--- a/src/useq/_base_model.py
+++ b/src/useq/_base_model.py
@@ -18,9 +18,11 @@ from typing import (
 
 import numpy as np
 from pydantic import BaseModel
-from pydantic_compat import PYDANTIC2, PydanticCompatMixin
+from pydantic_compat import PydanticCompatMixin
 
 if TYPE_CHECKING:
+    from pydantic import ConfigDict
+
     ReprArgs = Sequence[Tuple[Optional[str], Any]]
     IncEx = set[int] | set[str] | dict[int, Any] | dict[str, Any] | None
 
@@ -31,20 +33,12 @@ _Y = TypeVar("_Y", bound="UseqModel")
 
 
 class FrozenModel(PydanticCompatMixin, BaseModel):
-    if PYDANTIC2:
-        model_config = {
-            "populate_by_name": True,
-            "extra": "ignore",
-            "frozen": True,
-        }
-
-    else:
-
-        class Config:
-            allow_population_by_field_name = True
-            extra = "ignore"
-            frozen = True
-            json_encoders: ClassVar[dict] = {MappingProxyType: dict}
+    model_config: ClassVar[ConfigDict] = {  # type: ignore
+        "populate_by_name": True,
+        "extra": "ignore",  # type: ignore
+        "frozen": True,
+        "json_encoders": {MappingProxyType: dict},
+    }
 
     def replace(self: _T, **kwargs: Any) -> _T:
         """Return a new instance replacing specified kwargs with new values.

--- a/src/useq/_base_model.py
+++ b/src/useq/_base_model.py
@@ -33,9 +33,9 @@ _Y = TypeVar("_Y", bound="UseqModel")
 
 
 class FrozenModel(PydanticCompatMixin, BaseModel):
-    model_config: ClassVar[ConfigDict] = {  # type: ignore
+    model_config: ClassVar[ConfigDict] = {
         "populate_by_name": True,
-        "extra": "ignore",  # type: ignore
+        "extra": "ignore",
         "frozen": True,
         "json_encoders": {MappingProxyType: dict},
     }

--- a/src/useq/_base_model.py
+++ b/src/useq/_base_model.py
@@ -18,9 +18,7 @@ from typing import (
 
 import numpy as np
 from pydantic import BaseModel
-from pydantic_compat import PydanticCompatMixin
-
-from useq._pydantic_compat import PYDANTIC2
+from pydantic_compat import PYDANTIC2, PydanticCompatMixin
 
 if TYPE_CHECKING:
     ReprArgs = Sequence[Tuple[Optional[str], Any]]

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -4,11 +4,21 @@ import contextlib
 import math
 from enum import Enum
 from functools import partial
-from typing import Any, Callable, Iterator, NamedTuple, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Iterator,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import numpy as np
-from pydantic import Field
-from pydantic_compat import PYDANTIC2, field_validator
+from pydantic import ConfigDict, Field
+from pydantic_compat import field_validator
 
 from useq._base_model import FrozenModel
 from useq._pydantic_compat import FROZEN
@@ -124,13 +134,7 @@ class _GridPlan(FrozenModel):
     """
 
     # Overriding FrozenModel to make fov_width and fov_height mutable.
-    if PYDANTIC2:
-        model_config = {"validate_assignment": True, "frozen": False}
-    else:
-
-        class Config:
-            validate_assignment = True
-            frozen = False
+    model_config: ClassVar[ConfigDict] = {"validate_assignment": True, "frozen": False}
 
     overlap: Tuple[float, float] = Field((0.0, 0.0), **FROZEN)  # type: ignore
     mode: OrderMode = Field(OrderMode.row_wise_snake, **FROZEN)  # type: ignore

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -8,9 +8,10 @@ from typing import Any, Callable, Iterator, NamedTuple, Optional, Sequence, Tupl
 
 import numpy as np
 from pydantic import Field
+from pydantic_compat import PYDANTIC2, field_validator
 
 from useq._base_model import FrozenModel
-from useq._pydantic_compat import FROZEN, PYDANTIC2, field_validator
+from useq._pydantic_compat import FROZEN
 
 
 class RelativeTo(Enum):

--- a/src/useq/_hardware_autofocus.py
+++ b/src/useq/_hardware_autofocus.py
@@ -5,7 +5,6 @@ from pydantic import PrivateAttr
 from useq._actions import HardwareAutofocus
 from useq._base_model import FrozenModel
 from useq._mda_event import MDAEvent
-from useq._pydantic_compat import model_copy
 
 
 class AutoFocusPlan(FrozenModel):
@@ -46,7 +45,7 @@ class AutoFocusPlan(FrozenModel):
             if zplan and zplan.is_relative and "z" in event.index:
                 updates["z_pos"] = event.z_pos - list(zplan)[event.index["z"]]
 
-        return model_copy(event, update=updates)
+        return event.model_copy(update=updates)
 
     def should_autofocus(self, event: MDAEvent) -> bool:
         """Method that must be implemented by a subclass.

--- a/src/useq/_iter_sequence.py
+++ b/src/useq/_iter_sequence.py
@@ -13,7 +13,6 @@ from useq._grid import (  # noqa: TCH001
 )
 from useq._mda_event import Channel as EventChannel
 from useq._mda_event import MDAEvent
-from useq._pydantic_compat import model_construct, model_copy
 from useq._utils import AXES, Axis, _has_axes
 from useq._z import AnyZPlan  # noqa: TCH001  # noqa: TCH001
 
@@ -100,7 +99,7 @@ def iter_sequence(sequence: MDASequence) -> Iterator[MDAEvent]:
             for axis, idx in this_e.index.items()
             if idx != next_e.index[axis]
         ):
-            this_e = model_copy(this_e, update={"keep_shutter_open": True})
+            this_e = this_e.model_copy(update={"keep_shutter_open": True})
         yield this_e
         this_e = next_e
     yield this_e
@@ -169,8 +168,8 @@ def _iter_sequence(
         if position and position.name:
             event_kwargs["pos_name"] = position.name
         if channel:
-            event_kwargs["channel"] = model_construct(
-                EventChannel, config=channel.config, group=channel.group
+            event_kwargs["channel"] = EventChannel.model_construct(
+                config=channel.config, group=channel.group
             )
             if channel.exposure is not None:
                 event_kwargs["exposure"] = channel.exposure
@@ -205,8 +204,8 @@ def _iter_sequence(
                 # if the sub-sequence doe not have an autofocus plan, we override it
                 # with the parent sequence's autofocus plan
                 if not sub_seq.autofocus_plan:
-                    sub_seq = model_copy(
-                        sub_seq, update={"autofocus_plan": autofocus_plan}
+                    sub_seq = sub_seq.model_copy(
+                        update={"autofocus_plan": autofocus_plan}
                     )
 
                 # recurse into the sub-sequence
@@ -223,7 +222,7 @@ def _iter_sequence(
             elif position.sequence is not None and position.sequence.autofocus_plan:
                 autofocus_plan = position.sequence.autofocus_plan
 
-        event = model_construct(MDAEvent, **event_kwargs)
+        event = MDAEvent.model_construct(**event_kwargs)
         if autofocus_plan:
             af_event = autofocus_plan.event(event)
             if af_event:

--- a/src/useq/_mda_event.py
+++ b/src/useq/_mda_event.py
@@ -19,7 +19,11 @@ from pydantic import Field
 
 from useq._actions import AcquireImage, AnyAction
 from useq._base_model import UseqModel
-from useq._pydantic_compat import PYDANTIC2, field_serializer
+
+try:
+    from pydantic import field_serializer
+except ImportError:
+    field_serializer = None  # type: ignore
 
 if TYPE_CHECKING:
     from useq._mda_sequence import MDASequence
@@ -166,7 +170,7 @@ class MDAEvent(UseqModel):
 
         return to_pycromanager(self)
 
-    if PYDANTIC2:
+    if field_serializer is not None:
         _si = field_serializer("index", mode="plain")(lambda v: dict(v))
         _sx = field_serializer("x_pos", mode="plain")(_float_or_none)
         _sy = field_serializer("y_pos", mode="plain")(_float_or_none)

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -223,7 +223,7 @@ class MDASequence(UseqModel):
 
     @model_validator(mode="after")
     @classmethod
-    def _validate_mda(cls, values: MDASequence) -> MDASequence:
+    def _validate_mda(cls, values: Any) -> Any:
         if values.axis_order:
             cls._check_order(
                 values.axis_order,

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -7,6 +7,7 @@ from warnings import warn
 
 import numpy as np
 from pydantic import Field, PrivateAttr
+from pydantic_compat import field_validator, model_validator
 
 from useq._base_model import UseqModel
 from useq._channel import Channel
@@ -14,11 +15,7 @@ from useq._grid import AnyGridPlan, GridPosition  # noqa: TCH001
 from useq._hardware_autofocus import AnyAutofocusPlan, AxesBasedAF
 from useq._iter_sequence import iter_sequence
 from useq._position import Position
-from useq._pydantic_compat import (
-    field_validator,
-    model_validator,
-    pydantic_1_style_root_dict,
-)
+from useq._pydantic_compat import pydantic_1_style_root_dict
 from useq._time import AnyTimePlan  # noqa: TCH001
 from useq._utils import AXES, Axis, TimeEstimate, estimate_sequence_duration
 from useq._z import AnyZPlan  # noqa: TCH001

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -16,8 +16,6 @@ from useq._iter_sequence import iter_sequence
 from useq._position import Position
 from useq._pydantic_compat import (
     field_validator,
-    model_construct,
-    model_dump,
     model_validator,
     pydantic_1_style_root_dict,
 )
@@ -176,7 +174,7 @@ class MDASequence(UseqModel):
             if isinstance(v, Channel):
                 channels.append(v)
             elif isinstance(v, str):
-                channels.append(model_construct(Channel, config=v))
+                channels.append(Channel.model_construct(config=v))
             elif isinstance(v, dict):
                 channels.append(Channel(**v))
             else:  # pragma: no cover
@@ -259,7 +257,7 @@ class MDASequence(UseqModel):
         """Return `True` if two `MDASequences` are equal (uid is excluded)."""
         if isinstance(other, MDASequence):
             return bool(
-                model_dump(self, exclude={"uid"}) == model_dump(other, exclude={"uid"})
+                self.model_dump(exclude={"uid"}) == other.model_dump(exclude={"uid"})
             )
         else:
             return False

--- a/src/useq/_pydantic_compat.py
+++ b/src/useq/_pydantic_compat.py
@@ -1,11 +1,6 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 import pydantic.version
-from pydantic import BaseModel
-
-BM = TypeVar("BM", bound=BaseModel)
 
 __all__ = ["field_serializer", "model_serializer"]
 
@@ -13,18 +8,9 @@ __all__ = ["field_serializer", "model_serializer"]
 if pydantic.version.VERSION.startswith("2"):
     from pydantic import field_serializer, model_serializer
 
-    def pydantic_1_style_root_dict(cls: type[BM], values: BM) -> dict:
-        # deal with the fact that in pydantic1
-        # root_validator after returned a dict of {field_name -> validated_value}
-        # but in pydantic2 it returns the complete validated model instance
-        return {k: getattr(values, k) for k in cls.model_fields}
-
     FROZEN = {"frozen": True}
 
 elif not TYPE_CHECKING:
-
-    def pydantic_1_style_root_dict(cls: type[BM], values: dict) -> dict:
-        return values
 
     def model_serializer(**kwargs):
         return lambda f: f  # pragma: no cover

--- a/src/useq/_pydantic_compat.py
+++ b/src/useq/_pydantic_compat.py
@@ -5,10 +5,6 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar
 import pydantic.version
 from pydantic import BaseModel
 
-if TYPE_CHECKING:
-    from pydantic.fields import FieldInfo
-
-
 PYDANTIC2 = pydantic.version.VERSION.startswith("2")
 BM = TypeVar("BM", bound=BaseModel)
 
@@ -18,7 +14,6 @@ __all__ = [
     "field_validator",
     "field_serializer",
     "model_serializer",
-    "model_fields",
 ]
 
 
@@ -30,28 +25,10 @@ if PYDANTIC2:
         model_validator,
     )
 
-    def model_fields(obj: BaseModel | type[BaseModel]) -> dict[str, FieldInfo]:
-        return obj.model_fields
-
     def field_validator(*args: Any, **kwargs: Any) -> Callable[[Callable], Callable]:
         kwargs.pop("always", None)
         kwargs.pop("allow_reuse", None)
         return functional_validators.field_validator(*args, **kwargs)
-
-    def model_dump(obj: BaseModel, **kwargs: Any) -> dict[str, Any]:
-        return obj.model_dump(**kwargs)
-
-    def model_dump_json(obj: BaseModel, **kwargs: Any) -> str:
-        return obj.model_dump_json(**kwargs)
-
-    def model_rebuild(obj: type[BaseModel], **kwargs: Any) -> bool | None:
-        return obj.model_rebuild(_types_namespace=kwargs)
-
-    def model_construct(obj: type[BM], **kwargs: Any) -> BM:
-        return obj.model_construct(**kwargs)
-
-    def model_copy(obj: BM, **kwargs: Any) -> BM:
-        return obj.model_copy(**kwargs)
 
     def pydantic_1_style_root_dict(cls: type[BM], values: BM) -> dict:
         # deal with the fact that in pydantic1
@@ -64,11 +41,6 @@ if PYDANTIC2:
 elif not TYPE_CHECKING:
     from pydantic import root_validator, validator
 
-    def model_fields(
-        obj: BaseModel | type[BaseModel],
-    ) -> dict[str, Any]:
-        return obj.__fields__
-
     def model_validator(**kwargs: Any) -> Callable[[Callable], Callable]:
         if kwargs.pop("mode", None) == "before":
             kwargs["pre"] = True  # pragma: no cover
@@ -78,21 +50,6 @@ elif not TYPE_CHECKING:
         if kwargs.pop("mode", None) == "before":
             kwargs["pre"] = True
         return validator(*fields, **kwargs)
-
-    def model_dump(obj: BaseModel, **kwargs: Any) -> dict[str, Any]:
-        return obj.dict(**kwargs)
-
-    def model_copy(obj: BM, **kwargs: Any) -> BM:
-        return obj.copy(**kwargs)
-
-    def model_dump_json(obj: BaseModel, **kwargs: Any) -> str:
-        return obj.json(**kwargs)
-
-    def model_rebuild(obj: type[BM], **kwargs: Any) -> None:
-        obj.update_forward_refs(**kwargs)
-
-    def model_construct(obj: type[BM], **kwargs: Any) -> BM:
-        return obj.construct(**kwargs)
 
     def pydantic_1_style_root_dict(cls: type[BM], values: dict) -> dict:
         return values

--- a/src/useq/_pydantic_compat.py
+++ b/src/useq/_pydantic_compat.py
@@ -1,34 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import pydantic.version
 from pydantic import BaseModel
 
-PYDANTIC2 = pydantic.version.VERSION.startswith("2")
 BM = TypeVar("BM", bound=BaseModel)
 
-__all__ = [
-    "PYDANTIC2",
-    "model_validator",
-    "field_validator",
-    "field_serializer",
-    "model_serializer",
-]
+__all__ = ["field_serializer", "model_serializer"]
 
 
-if PYDANTIC2:
-    from pydantic import (
-        field_serializer,
-        functional_validators,
-        model_serializer,
-        model_validator,
-    )
-
-    def field_validator(*args: Any, **kwargs: Any) -> Callable[[Callable], Callable]:
-        kwargs.pop("always", None)
-        kwargs.pop("allow_reuse", None)
-        return functional_validators.field_validator(*args, **kwargs)
+if pydantic.version.VERSION.startswith("2"):
+    from pydantic import field_serializer, model_serializer
 
     def pydantic_1_style_root_dict(cls: type[BM], values: BM) -> dict:
         # deal with the fact that in pydantic1
@@ -39,17 +22,6 @@ if PYDANTIC2:
     FROZEN = {"frozen": True}
 
 elif not TYPE_CHECKING:
-    from pydantic import root_validator, validator
-
-    def model_validator(**kwargs: Any) -> Callable[[Callable], Callable]:
-        if kwargs.pop("mode", None) == "before":
-            kwargs["pre"] = True  # pragma: no cover
-        return root_validator(**kwargs)
-
-    def field_validator(*fields: str, **kwargs: Any) -> Callable[[Callable], Callable]:
-        if kwargs.pop("mode", None) == "before":
-            kwargs["pre"] = True
-        return validator(*fields, **kwargs)
 
     def pydantic_1_style_root_dict(cls: type[BM], values: dict) -> dict:
         return values

--- a/src/useq/_utils.py
+++ b/src/useq/_utils.py
@@ -4,8 +4,6 @@ import re
 from datetime import timedelta
 from typing import TYPE_CHECKING, Literal, NamedTuple, TypeVar
 
-from useq._pydantic_compat import model_copy
-
 if TYPE_CHECKING:
     from typing import Final
 
@@ -104,7 +102,7 @@ def estimate_sequence_duration(seq: useq.MDASequence) -> TimeEstimate:
                 for field in ("time_plan", "z_plan", "grid_plan", "channels")
                 if getattr(parent_seq, field) and not getattr(p.sequence, field)
             }
-            sub_seq = model_copy(p.sequence, update=updates)
+            sub_seq = p.sequence.model_copy(update=updates)
         estimate += _estimate_simple_sequence_duration(sub_seq)
     return estimate
 

--- a/src/useq/_z.py
+++ b/src/useq/_z.py
@@ -4,13 +4,13 @@ import math
 from typing import Any, Callable, Iterator, List, Sequence, Union
 
 import numpy as np
+from pydantic_compat import field_validator
 
 from useq._base_model import FrozenModel
-from useq._pydantic_compat import field_validator
 
 
 def _list_cast(field: str) -> Callable[[Any], Any]:
-    v = field_validator(field, mode="before", allow_reuse=True, check_fields=False)
+    v = field_validator(field, mode="before", check_fields=False)
     return v(list)
 
 

--- a/src/useq/_z.py
+++ b/src/useq/_z.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Callable, Iterator, List, Sequence, Union
+from typing import Callable, Iterator, List, Sequence, Union
 
 import numpy as np
 from pydantic_compat import field_validator
@@ -9,7 +9,7 @@ from pydantic_compat import field_validator
 from useq._base_model import FrozenModel
 
 
-def _list_cast(field: str) -> Callable[[Any], Any]:
+def _list_cast(field: str) -> Callable:
     v = field_validator(field, mode="before", check_fields=False)
     return v(list)
 

--- a/tests/test_autofocus.py
+++ b/tests/test_autofocus.py
@@ -6,7 +6,6 @@ import pytest
 
 import useq
 from useq import AxesBasedAF, HardwareAutofocus, MDASequence
-from useq._pydantic_compat import model_copy
 
 ZRANGE2 = useq.ZRangeAround(range=2, step=1)
 ZPOS_30 = useq.Position(z=30.0)
@@ -19,10 +18,10 @@ TWO_CH_TWO_P_T = TWO_CH_TWO_P.replace(time_plan={"interval": 1, "loops": 2})
 NO_CH_ZSTACK = MDASequence(stage_positions=[ZPOS_30], z_plan=ZRANGE2)
 TWO_CH_ZSTACK = NO_CH_ZSTACK.replace(channels=["DAPI", "FITC"])
 AF = AxesBasedAF(autofocus_device_name="Z", autofocus_motor_offset=40, axes=())
-AF_C = model_copy(AF, update={"axes": ("c",)})
-AF_G = model_copy(AF, update={"axes": ("g",)})
-AF_P = model_copy(AF, update={"axes": ("p",)})
-AF_Z = model_copy(AF, update={"axes": ("z",)})
+AF_C = AF.model_copy(update={"axes": ("c",)})
+AF_G = AF.model_copy(update={"axes": ("g",)})
+AF_P = AF.model_copy(update={"axes": ("p",)})
+AF_Z = AF.model_copy(update={"axes": ("z",)})
 AF_SEQ_C = MDASequence(autofocus_plan=AF_C)
 SUB_P_AF_C = useq.Position(z=10, sequence=AF_SEQ_C)
 SUB_P_AF_G = useq.Position(z=10, sequence=MDASequence(autofocus_plan=AF_G))
@@ -70,7 +69,7 @@ def test_autofocus(
     expected_af_indices: Iterable[int],
 ) -> None:
     if af_axes:
-        mda = mda.replace(autofocus_plan=model_copy(AF, update={"axes": af_axes}))
+        mda = mda.replace(autofocus_plan=AF.model_copy(update={"axes": af_axes}))
         assert isinstance(mda.autofocus_plan, AxesBasedAF)
         assert mda.autofocus_plan.axes == af_axes
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from contextlib import nullcontext
-
 import numpy as np
 import pytest
 
 import useq
-from useq._pydantic_compat import PYDANTIC2
 
 
 def test_from_numpy() -> None:
@@ -152,6 +149,4 @@ def test_pydantic_compat(mda1: useq.MDASequence) -> None:
     assert mda1.model_dump_json()
 
     assert mda1.model_dump()
-    ctx = pytest.warns(DeprecationWarning) if PYDANTIC2 else nullcontext()
-    with ctx:  # type: ignore
-        assert mda1.dict()
+    assert mda1.dict()

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -22,7 +22,6 @@ from useq import (
     ZRelativePositions,
 )
 from useq._grid import GridPosition
-from useq._pydantic_compat import PYDANTIC2
 
 _T = List[Tuple[Any, Sequence[float]]]
 
@@ -279,13 +278,9 @@ def test_combinations(
 
 @pytest.mark.parametrize("cls", [MDASequence, MDAEvent])
 def test_schema(cls: BaseModel) -> None:
-    if PYDANTIC2:
-        schema = cls.model_json_schema()
-        assert schema
-        assert json.dumps(schema)
-    else:
-        assert cls.schema()
-        assert cls.schema_json()
+    schema = cls.model_json_schema()
+    assert schema
+    assert json.dumps(schema)
 
 
 def test_z_position() -> None:


### PR DESCRIPTION
I pulled out most of the pydantic cross-compatibility stuff that I added in #122  (along with stuff I did for ome-types and psygnal), and make a new library: https://github.com/tlambert03/pydantic-compat

this PR uses it and pulls out most of the patch logic here