### PR TITLE
fix: fix rounding error in ZPlan num_positions estimate

### DIFF
--- a/src/useq/_z.py
+++ b/src/useq/_z.py
@@ -28,11 +28,13 @@ class ZPlan(FrozenModel):
 
     def positions(self) -> Sequence[float]:
         start, stop, step = self._start_stop_step()
-        return list(np.arange(start, stop + step, step))
+        stop += step / 2  # make sure we include the last point
+        return list(np.arange(start, stop, step))
 
     def num_positions(self) -> int:
         start, stop, step = self._start_stop_step()
-        return math.ceil((stop + step - start) / step)
+        nsteps = (stop + step - start) / step
+        return math.ceil(round(nsteps, 6))
 
     @property
     def is_relative(self) -> bool:
@@ -49,9 +51,9 @@ class ZTopBottom(ZPlan):
     Attributes
     ----------
     top : float
-        Top position (inclusive).
+        Top position in microns (inclusive).
     bottom : float
-        Bottom position (inclusive).
+        Bottom position in microns (inclusive).
     step : float
         Step size in microns.
     go_up : bool

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -398,3 +398,10 @@ def test_keep_shutter_open() -> None:
     )
     for event in mda5:
         assert event.keep_shutter_open != (event.index["g"] == 3)
+
+
+def test_z_plan_num_position():
+    for i in range(1, 100):
+        plan = ZRangeAround(range=(i - 1) / 10, step=0.1)
+        assert plan.num_positions() == i
+        assert len(list(plan)) == i


### PR DESCRIPTION
fixes a rounding issue when calculating the number of steps in a Zplan