### PR TITLE
feat: accept bare string for mda event channel

### DIFF
--- a/src/useq/_mda_event.py
+++ b/src/useq/_mda_event.py
@@ -15,7 +15,7 @@ from typing import (
     Tuple,
 )
 
-from pydantic import Field
+from pydantic_compat import Field, field_validator
 
 from useq._actions import AcquireImage, AnyAction
 from useq._base_model import UseqModel
@@ -157,6 +157,10 @@ class MDAEvent(UseqModel):
             stacklevel=2,
         )
         return 0
+
+    @field_validator("channel", mode="before")
+    def _validate_channel(cls, val: Any) -> Any:
+        return Channel(config=val) if isinstance(val, str) else val
 
     def to_pycromanager(self) -> "PycroManagerEvent":
         from useq.pycromanager import to_pycromanager

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -405,3 +405,7 @@ def test_z_plan_num_position():
         plan = ZRangeAround(range=(i - 1) / 10, step=0.1)
         assert plan.num_positions() == i
         assert len(list(plan)) == i
+
+
+def test_channel_str():
+    assert MDAEvent(channel="DAPI") == MDAEvent(channel={"config": "DAPI"})


### PR DESCRIPTION
```python
MDAEvent(channel="DAPI") == MDAEvent(channel={"config": "DAPI"})
```