### PR TITLE
refactor!: change axis_order type to `Tuple[str, ...]`

### DIFF
--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Sequence, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    Optional,
+    Sequence,
+    Tuple,
+)
 from uuid import UUID, uuid4
 from warnings import warn
 
@@ -104,7 +113,7 @@ class MDASequence(UseqModel):
     """
 
     metadata: Dict[str, Any] = Field(default_factory=dict)
-    axis_order: str = "".join(AXES)
+    axis_order: Tuple[str, ...] = AXES
     stage_positions: Tuple[Position, ...] = Field(default_factory=tuple)
     grid_plan: Optional[AnyGridPlan] = None
     channels: Tuple[Channel, ...] = Field(default_factory=tuple)
@@ -207,10 +216,10 @@ class MDASequence(UseqModel):
         return {"phases": v} if isinstance(v, (tuple, list)) else v or None
 
     @field_validator("axis_order", mode="before")
-    def _validate_axis_order(cls, v: Any) -> str:
-        if not isinstance(v, str):
-            raise ValueError(f"acquisition order must be a string, got {type(v)}")
-        order = v.lower()
+    def _validate_axis_order(cls, v: Any) -> tuple[str, ...]:
+        if not isinstance(v, Iterable):
+            raise ValueError(f"axis_order must be iterable, got {type(v)}")
+        order = tuple(str(x).lower() for x in v)
         extra = {x for x in order if x not in AXES}
         if extra:
             raise ValueError(

--- a/tests/fixtures/mda.json
+++ b/tests/fixtures/mda.json
@@ -6,7 +6,13 @@
       "c"
     ]
   },
-  "axis_order": "tpgcz",
+  "axis_order": [
+    "t",
+    "p",
+    "g",
+    "c",
+    "z"
+  ],
   "channels": [
     {
       "acquire_every": 1,
@@ -64,7 +70,13 @@
       "name": "test_name",
       "sequence": {
         "autofocus_plan": null,
-        "axis_order": "tpgcz",
+        "axis_order": [
+          "t",
+          "p",
+          "g",
+          "c",
+          "z"
+        ],
         "channels": [],
         "grid_plan": {
           "columns": 3,

--- a/tests/fixtures/mda.yaml
+++ b/tests/fixtures/mda.yaml
@@ -3,7 +3,12 @@ autofocus_plan:
   autofocus_motor_offset: 50.0
   axes:
   - c
-axis_order: tpgcz
+axis_order:
+- t
+- p
+- g
+- c
+- z
 channels:
 - config: Cy5
   exposure: 50.0
@@ -22,7 +27,12 @@ stage_positions:
   y: 20.0
 - name: test_name
   sequence:
-    axis_order: tpgcz
+    axis_order:
+    - t
+    - p
+    - g
+    - c
+    - z
     grid_plan:
       columns: 3
       mode: row_wise_snake

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -201,7 +201,7 @@ def test_stage_positions(position: Any, pexpectation: Sequence[float]) -> None:
 
 
 def test_axis_order_errors() -> None:
-    with pytest.raises(ValueError, match="acquisition order must be a"):
+    with pytest.raises(ValueError, match="axis_order must be iterable"):
         MDASequence(axis_order=1)
     with pytest.raises(ValueError, match="Duplicate entries found"):
         MDASequence(axis_order="tpgcztpgcz")
@@ -325,13 +325,13 @@ def test_shape_and_axes() -> None:
         z_plan=z_as_class[0][0], time_plan=t_as_class[0][0], axis_order="tzp"
     )
     assert mda.shape == (5, 7)
-    assert mda.axis_order == "tzp"
+    assert mda.axis_order == tuple("tzp")
     assert mda.used_axes == "tz"
     assert mda.sizes == {"t": 5, "z": 7, "p": 0}
 
     mda2 = mda.replace(axis_order="zptc")
     assert mda2.shape == (7, 5)
-    assert mda2.axis_order == "zptc"
+    assert mda2.axis_order == tuple("zptc")
     assert mda2.used_axes == "zt"
     assert mda2.sizes == {"z": 7, "p": 0, "t": 5, "c": 0}
 


### PR DESCRIPTION
fixes #138 

Changes:
```python
MDASequence:
    # this 
    axis_order: str = "".join(AXES)
    # to this
    axis_order: Tuple[str, ...] = AXES
```

the typing of `MDASequence.axis_order` was too strict.  It's fine to accept a string as input, but it should also be able to accept a sequence of strings, each of which may be more than a single character


@ianhi, can you think of anywhere you're assuming axis_order is a literal string, rather than generic sequence of strings?