### PR TITLE
Fix: update time interval exceeded boolean

### DIFF
--- a/src/useq/_utils.py
+++ b/src/useq/_utils.py
@@ -159,8 +159,24 @@ def _time_phase_duration(
         # to actually acquire the data
         time_interval_s = s_per_timepoint
 
-        # if p axes is before t axes, then the time interval is not exceeded
-        if list(axis_order).index("p") < list(axis_order).index("t"):
+        axis = list(axis_order)
+        # if there are no position and grid axes, then the time interval is not
+        # exceeded
+        if Axis.POSITION not in axis and Axis.GRID not in axis:
+            time_interval_exceeded = False
+        # if there are both position and grid axes, then the time interval, is not
+        # exceeded if the position and grid axes are before the time axis
+        elif Axis.POSITION in axis and Axis.GRID in axis:
+            if axis.index(Axis.POSITION) < axis.index(Axis.TIME) and axis.index(
+                Axis.GRID
+            ) < axis.index(Axis.TIME):
+                time_interval_exceeded = False
+        # if there is only one of position or grid axes, then the time interval is
+        # not exceeded if that axis is before the time axis
+        elif Axis.POSITION in axis:
+            if axis.index(Axis.POSITION) < axis.index(Axis.TIME):
+                time_interval_exceeded = False
+        elif axis.index(Axis.GRID) < axis.index(Axis.TIME):
             time_interval_exceeded = False
 
     tot_duration = (phase.num_timepoints() - 1) * time_interval_s + s_per_timepoint

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -439,3 +439,35 @@ def test_z_plan_num_position():
 
 def test_channel_str():
     assert MDAEvent(channel="DAPI") == MDAEvent(channel={"config": "DAPI"})
+
+
+def test_time_interval_exceeded():
+    main_seq = MDASequence(
+        axis_order="tc",
+        channels=[{"config": "DAPI", "exposure": 100}],
+        time_plan=TIntervalLoops(loops=10, interval=0),
+    )
+    assert not main_seq.estimate_duration().time_interval_exceeded
+
+    p_seq = main_seq.replace(axis_order="tpc", stage_position=[(1, 2, 3)])
+    assert p_seq.estimate_duration().time_interval_exceeded
+
+    p_seq = p_seq.replace(axis_order="ptc")
+    assert not p_seq.estimate_duration().time_interval_exceeded
+
+    g_seq = main_seq.replace(
+        axis_order="tgc", grid_plan=GridRelative(rows=1, columns=2)
+    )
+    assert g_seq.estimate_duration().time_interval_exceeded
+
+    g_seq = g_seq.replace(axis_order="gtc")
+    assert not g_seq.estimate_duration().time_interval_exceeded
+
+    pg_seq = g_seq.replace(axis_order="tpgc", stage_position=[(1, 2, 3)])
+    assert pg_seq.estimate_duration().time_interval_exceeded
+
+    pg_seq = pg_seq.replace(axis_order="ptcg")
+    assert pg_seq.estimate_duration().time_interval_exceeded
+
+    pg_seq = pg_seq.replace(axis_order="pgtc")
+    assert not pg_seq.estimate_duration().time_interval_exceeded


### PR DESCRIPTION
in case of a `time_plan` with `interval=0`, the `time_interval_exceeded` `boolean` should change depending on the sequence `axis_order`.

e.g.
if `axis_order="tpc"`, `time_interval_exceeded=True`
if `axis_order="ptc"`, `time_interval_exceeded=False`

