### PR TITLE
refactor: multi-point-plan

### DIFF
--- a/src/useq/__init__.py
+++ b/src/useq/__init__.py
@@ -10,8 +10,10 @@ from useq._grid import (
     GridRowsColumns,
     GridWidthHeight,
     MultiPointPlan,
+    OrderMode,
     RandomPoints,
     RelativeMultiPointPlan,
+    Shape,
 )
 from useq._hardware_autofocus import AnyAutofocusPlan, AutoFocusPlan, AxesBasedAF
 from useq._mda_event import MDAEvent, PropertyTuple
@@ -54,6 +56,7 @@ __all__ = [
     "MDASequence",
     "MultiPhaseTimePlan",
     "MultiPointPlan",
+    "OrderMode",
     "Position",  # alias for AbsolutePosition
     "PropertyTuple",
     "RandomPoints",
@@ -61,6 +64,7 @@ __all__ = [
     "registered_well_plate_keys",
     "RelativeMultiPointPlan",
     "RelativePosition",
+    "Shape",
     "TDurationLoops",
     "TIntervalDuration",
     "TIntervalLoops",
@@ -89,7 +93,7 @@ def __getattr__(name: str) -> Any:
         # )
 
         return GridRowsColumns
-    if name == "AnyGridPlan":
+    if name == "AnyGridPlan":  # pragma: no cover
         warnings.warn(
             "useq.AnyGridPlan has been renamed to useq.MultiPointPlan",
             DeprecationWarning,

--- a/src/useq/__init__.py
+++ b/src/useq/__init__.py
@@ -11,13 +11,14 @@ from useq._grid import (
     GridWidthHeight,
     MultiPointPlan,
     RandomPoints,
+    RelativeMultiPointPlan,
 )
 from useq._hardware_autofocus import AnyAutofocusPlan, AutoFocusPlan, AxesBasedAF
 from useq._mda_event import MDAEvent, PropertyTuple
 from useq._mda_sequence import MDASequence
 from useq._plate import WellPlate, WellPlatePlan
 from useq._plate_registry import register_well_plates, registered_well_plate_keys
-from useq._position import Position, RelativePosition
+from useq._position import AbsolutePosition, Position, RelativePosition
 from useq._time import (
     AnyTimePlan,
     MultiPhaseTimePlan,
@@ -35,13 +36,10 @@ from useq._z import (
 )
 
 __all__ = [
-    "Position",
+    "AbsolutePosition",
     "AcquireImage",
     "Action",
-    "register_well_plates",
-    "registered_well_plate_keys",
     "AnyAutofocusPlan",
-    "MultiPointPlan",
     "AnyTimePlan",
     "AnyZPlan",
     "AutoFocusPlan",
@@ -55,14 +53,19 @@ __all__ = [
     "MDAEvent",
     "MDASequence",
     "MultiPhaseTimePlan",
+    "MultiPointPlan",
+    "Position",  # alias for AbsolutePosition
     "PropertyTuple",
     "RandomPoints",
+    "register_well_plates",
+    "registered_well_plate_keys",
+    "RelativeMultiPointPlan",
     "RelativePosition",
     "TDurationLoops",
     "TIntervalDuration",
     "TIntervalLoops",
-    "WellPlatePlan",
     "WellPlate",
+    "WellPlatePlan",
     "ZAboveBelow",
     "ZAbsolutePositions",
     "ZRangeAround",

--- a/src/useq/__init__.py
+++ b/src/useq/__init__.py
@@ -1,14 +1,15 @@
 """Implementation agnostic schema for multi-dimensional microscopy experiments."""
 
+import warnings
 from typing import Any
 
 from useq._actions import AcquireImage, Action, HardwareAutofocus
 from useq._channel import Channel
 from useq._grid import (
-    AnyGridPlan,
     GridFromEdges,
     GridRowsColumns,
     GridWidthHeight,
+    MultiPointPlan,
     RandomPoints,
 )
 from useq._hardware_autofocus import AnyAutofocusPlan, AutoFocusPlan, AxesBasedAF
@@ -40,7 +41,7 @@ __all__ = [
     "register_well_plates",
     "registered_well_plate_keys",
     "AnyAutofocusPlan",
-    "AnyGridPlan",
+    "MultiPointPlan",
     "AnyTimePlan",
     "AnyZPlan",
     "AutoFocusPlan",
@@ -85,4 +86,11 @@ def __getattr__(name: str) -> Any:
         # )
 
         return GridRowsColumns
+    if name == "AnyGridPlan":
+        warnings.warn(
+            "useq.AnyGridPlan has been renamed to useq.MultiPointPlan",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return MultiPointPlan
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/useq/_base_model.py
+++ b/src/useq/_base_model.py
@@ -57,6 +57,10 @@ class _ReplaceableModel(BaseModel):
         """
         return type(self).model_validate({**self.model_dump(exclude={"uid"}), **kwargs})
 
+    def __repr_args__(self) -> "ReprArgs":
+        """Only show fields that are not None or equal to their default value."""
+        return _non_default_repr_args(self, super().__repr_args__())
+
 
 class FrozenModel(_ReplaceableModel):
     model_config: ClassVar["ConfigDict"] = ConfigDict(
@@ -66,10 +70,6 @@ class FrozenModel(_ReplaceableModel):
         json_encoders={MappingProxyType: dict},
     )
 
-    def __repr_args__(self) -> "ReprArgs":
-        """Only show fields that are not None or equal to their default value."""
-        return _non_default_repr_args(self, super().__repr_args__())
-
 
 class MutableModel(_ReplaceableModel):
     model_config: ClassVar["ConfigDict"] = ConfigDict(
@@ -78,14 +78,6 @@ class MutableModel(_ReplaceableModel):
         validate_default=True,
         extra="ignore",
     )
-
-    def __repr_args__(self) -> "ReprArgs":
-        """Only show fields that are not None or equal to their default value."""
-        return _non_default_repr_args(self, super().__repr_args__())
-
-    def replace(self, **kwargs: Any) -> "Self":
-        """Return a new instance replacing specified kwargs with new values."""
-        return type(self).model_validate({**self.model_dump(exclude={"uid"}), **kwargs})
 
 
 class UseqModel(FrozenModel):

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -271,6 +271,10 @@ class GridFromEdges(_GridPlan[AbsolutePosition]):
     bottom: float = Field(..., frozen=True)
     right: float = Field(..., frozen=True)
 
+    @property
+    def is_relative(self) -> bool:
+        return False
+
     def _nrows(self, dy: float) -> int:
         total_height = abs(self.top - self.bottom) + dy
         return math.ceil(total_height / dy)
@@ -321,10 +325,6 @@ class GridRowsColumns(_GridPlan[RelativePosition]):
     rows: int = Field(..., frozen=True, ge=1)
     columns: int = Field(..., frozen=True, ge=1)
     relative_to: RelativeTo = Field(RelativeTo.center, frozen=True)
-
-    @property
-    def is_relative(self) -> bool:
-        return True
 
     def _nrows(self, dy: float) -> int:
         return self.rows
@@ -383,10 +383,6 @@ class GridWidthHeight(_GridPlan[RelativePosition]):
     width: float = Field(..., frozen=True, gt=0)
     height: float = Field(..., frozen=True, gt=0)
     relative_to: RelativeTo = Field(RelativeTo.center, frozen=True)
-
-    @property
-    def is_relative(self) -> bool:
-        return True
 
     def _nrows(self, dy: float) -> int:
         return math.ceil(self.height / dy)
@@ -454,10 +450,6 @@ class RandomPoints(_MultiPointPlan[RelativePosition]):
     shape: Shape = Shape.ELLIPSE
     random_seed: Optional[int] = None
     allow_overlap: bool = True
-
-    @property
-    def is_relative(self) -> bool:
-        return True
 
     def __iter__(self) -> Iterator[RelativePosition]:  # type: ignore [override]
         seed = np.random.RandomState(self.random_seed)

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -20,7 +20,7 @@ from pydantic import Field, PrivateAttr, field_validator, model_validator
 
 from useq._base_model import UseqModel
 from useq._channel import Channel
-from useq._grid import AnyGridPlan  # noqa: TCH001
+from useq._grid import MultiPointPlan  # noqa: TCH001
 from useq._hardware_autofocus import AnyAutofocusPlan, AxesBasedAF
 from useq._iter_sequence import iter_sequence
 from useq._plate import WellPlatePlan  # noqa: TCH001
@@ -184,7 +184,7 @@ class MDASequence(UseqModel):
     stage_positions: Union[WellPlatePlan, Tuple[Position, ...]] = Field(
         default_factory=tuple
     )
-    grid_plan: Optional[AnyGridPlan] = None
+    grid_plan: Optional[MultiPointPlan] = None
     channels: Tuple[Channel, ...] = Field(default_factory=tuple)
     time_plan: Optional[AnyTimePlan] = None
     z_plan: Optional[AnyZPlan] = None
@@ -317,7 +317,7 @@ class MDASequence(UseqModel):
         z_plan: Optional[AnyZPlan] = None,
         stage_positions: Sequence[Position] = (),
         channels: Sequence[Channel] = (),
-        grid_plan: Optional[AnyGridPlan] = None,
+        grid_plan: Optional[MultiPointPlan] = None,
         autofocus_plan: Optional[AnyAutofocusPlan] = None,
     ) -> None:
         if (

--- a/src/useq/_plate.py
+++ b/src/useq/_plate.py
@@ -21,7 +21,7 @@ from pydantic_core import core_schema
 from typing_extensions import Annotated
 
 from useq._base_model import FrozenModel
-from useq._grid import GridRowsColumns, RandomPoints, Shape, _PointsPlan
+from useq._grid import RandomPoints, RelativeMultiPointPlan, Shape
 from useq._plate_registry import _PLATE_REGISTRY
 from useq._position import Position, PositionBase, RelativePosition
 
@@ -159,9 +159,7 @@ class WellPlatePlan(FrozenModel, Sequence[Position]):
     a1_center_xy: Tuple[float, float]
     rotation: Union[float, None] = None
     selected_wells: Union[IndexExpression, None] = None
-    well_points_plan: Union[GridRowsColumns, RandomPoints, RelativePosition] = Field(
-        default_factory=lambda: RelativePosition(x=0, y=0)
-    )
+    well_points_plan: RelativeMultiPointPlan = Field(default_factory=RelativePosition)
 
     @field_validator("plate", mode="before")
     @classmethod
@@ -414,9 +412,7 @@ class WellPlatePlan(FrozenModel, Sequence[Position]):
             ax.add_patch(sh)
 
         ################ plot image positions ################
-        w = h = None
-        if isinstance(self.well_points_plan, _PointsPlan):
-            w, h = self.well_points_plan.fov_width, self.well_points_plan.fov_height
+        w, h = self.well_points_plan.fov_width, self.well_points_plan.fov_height
 
         for img_point in self.image_positions:
             x, y = float(img_point.x), float(img_point.y)  # type: ignore[arg-type] # µm

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -1,13 +1,4 @@
-from typing import (
-    TYPE_CHECKING,
-    ClassVar,
-    Generic,
-    Iterator,
-    Literal,
-    Optional,
-    SupportsIndex,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Generic, Iterator, Optional, SupportsIndex, TypeVar
 
 from pydantic import Field
 
@@ -110,7 +101,7 @@ class _MultiPointPlan(MutableModel, Generic[PositionT]):
         raise NotImplementedError("This method must be implemented by subclasses.")
 
 
-class RelativePosition(PositionBase, _MultiPointPlan):
+class RelativePosition(PositionBase, _MultiPointPlan["RelativePosition"]):
     """A relative position in 3D space.
 
     Relative positions also support `fov_width` and `fov_height` attributes, and can
@@ -120,7 +111,10 @@ class RelativePosition(PositionBase, _MultiPointPlan):
     x: float = 0
     y: float = 0
     z: float = 0
-    is_relative: ClassVar[Literal[True]] = True
+
+    @property
+    def is_relative(self) -> bool:
+        return True
 
     def __iter__(self) -> Iterator["RelativePosition"]:  # type: ignore [override]
         yield self

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -92,7 +92,7 @@ class _MultiPointPlan(MutableModel, Generic[PositionT]):
 
     @property
     def is_relative(self) -> bool:
-        return False
+        return True
 
     def __iter__(self) -> Iterator[PositionT]:  # type: ignore [override]
         raise NotImplementedError("This method must be implemented by subclasses.")
@@ -111,10 +111,6 @@ class RelativePosition(PositionBase, _MultiPointPlan["RelativePosition"]):
     x: float = 0
     y: float = 0
     z: float = 0
-
-    @property
-    def is_relative(self) -> bool:
-        return True
 
     def __iter__(self) -> Iterator["RelativePosition"]:  # type: ignore [override]
         yield self

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable, Optional
+from typing import TYPE_CHECKING, Iterable, Optional, get_args
 
 import pytest
 
-from useq import GridFromEdges, GridRowsColumns, GridWidthHeight, RandomPoints
+from useq import (
+    GridFromEdges,
+    GridRowsColumns,
+    GridWidthHeight,
+    RandomPoints,
+    RelativeMultiPointPlan,
+    RelativePosition,
+)
 from useq._grid import OrderMode, _rect_indices, _spiral_indices
 
 if TYPE_CHECKING:
@@ -147,3 +154,21 @@ def test_random_points(n_points: int, shape: str, seed: Optional[int]) -> None:
     else:
         with pytest.raises(UserWarning, match="Unable to generate"):
             list(rp)
+
+
+fov = {"fov_height": 200, "fov_width": 200}
+
+
+@pytest.mark.parametrize(
+    "obj",
+    [
+        GridRowsColumns(rows=1, columns=2, **fov),
+        GridWidthHeight(width=10, height=10, **fov),
+        RandomPoints(num_points=10, **fov),
+        RelativePosition(**fov),
+    ],
+)
+def test_points_plans(obj: RelativeMultiPointPlan):
+    assert isinstance(obj, get_args(RelativeMultiPointPlan))
+    assert all(isinstance(x, RelativePosition) for x in obj)
+    assert isinstance(obj.num_positions(), int)


### PR DESCRIPTION
This PR goes farther to formalize the relationship between all of the values in a `well_points_plan`,  namely, they are all `RelativeMultiPointPlan`  where

```python
RelativeMultiPointPlan = Union[
    GridRowsColumns, GridWidthHeight, RandomPoints, RelativePosition
]
```

and they all support 

```python
    def __iter__(self) -> Iterator[RelativePosition]: ...
    def num_positions(self) -> int: ...
```

it also adds fov_height and width to the RelativePosition