### PR TITLE
feat: formalizing point-visiting strategies

### DIFF
--- a/src/useq/__init__.py
+++ b/src/useq/__init__.py
@@ -19,7 +19,7 @@ from useq._mda_event import MDAEvent, PropertyTuple
 from useq._mda_sequence import MDASequence
 from useq._plate import WellPlate, WellPlatePlan
 from useq._plate_registry import register_well_plates, registered_well_plate_keys
-from useq._point_visiting import GridOrder
+from useq._point_visiting import GridOrder, TraversalOrder
 from useq._position import AbsolutePosition, Position, RelativePosition
 from useq._time import (
     AnyTimePlan,
@@ -68,6 +68,7 @@ __all__ = [
     "TDurationLoops",
     "TIntervalDuration",
     "TIntervalLoops",
+    "TraversalOrder",
     "WellPlate",
     "WellPlatePlan",
     "ZAboveBelow",

--- a/src/useq/__init__.py
+++ b/src/useq/__init__.py
@@ -10,7 +10,6 @@ from useq._grid import (
     GridRowsColumns,
     GridWidthHeight,
     MultiPointPlan,
-    OrderMode,
     RandomPoints,
     RelativeMultiPointPlan,
     Shape,
@@ -20,6 +19,7 @@ from useq._mda_event import MDAEvent, PropertyTuple
 from useq._mda_sequence import MDASequence
 from useq._plate import WellPlate, WellPlatePlan
 from useq._plate_registry import register_well_plates, registered_well_plate_keys
+from useq._point_visiting import GridOrder
 from useq._position import AbsolutePosition, Position, RelativePosition
 from useq._time import (
     AnyTimePlan,
@@ -56,7 +56,7 @@ __all__ = [
     "MDASequence",
     "MultiPhaseTimePlan",
     "MultiPointPlan",
-    "OrderMode",
+    "GridOrder",
     "Position",  # alias for AbsolutePosition
     "PropertyTuple",
     "RandomPoints",

--- a/src/useq/__init__.py
+++ b/src/useq/__init__.py
@@ -19,7 +19,7 @@ from useq._mda_event import MDAEvent, PropertyTuple
 from useq._mda_sequence import MDASequence
 from useq._plate import WellPlate, WellPlatePlan
 from useq._plate_registry import register_well_plates, registered_well_plate_keys
-from useq._point_visiting import GridOrder, TraversalOrder
+from useq._point_visiting import OrderMode, TraversalOrder
 from useq._position import AbsolutePosition, Position, RelativePosition
 from useq._time import (
     AnyTimePlan,
@@ -56,7 +56,7 @@ __all__ = [
     "MDASequence",
     "MultiPhaseTimePlan",
     "MultiPointPlan",
-    "GridOrder",
+    "OrderMode",
     "Position",  # alias for AbsolutePosition
     "PropertyTuple",
     "RandomPoints",

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -385,7 +385,7 @@ class RandomPoints(_MultiPointPlan[RelativePosition]):
     shape: Shape = Shape.ELLIPSE
     random_seed: Optional[int] = None
     allow_overlap: bool = True
-    order: TraversalOrder | None = None
+    order: Optional[TraversalOrder] = None
     start_at: int = 0
 
     @model_validator(mode="after")

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -363,9 +363,9 @@ class RandomPoints(_MultiPointPlan[RelativePosition]):
     num_points : int
         Number of points to generate.
     max_width : float
-        Maximum width of the bounding box.
+        Maximum width of the bounding box in microns.
     max_height : float
-        Maximum height of the bounding box.
+        Maximum height of the bounding box in microns.
     shape : Shape
         Shape of the bounding box. Current options are "ellipse" and "rectangle".
     random_seed : Optional[int]

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -29,7 +29,11 @@ from useq._position import (
 )
 
 if TYPE_CHECKING:
-    from typing_extensions import Annotated, Self
+    from typing_extensions import Annotated, Self, TypeAlias
+
+    PointGenerator: TypeAlias = Callable[
+        [np.random.RandomState, int, float, float], Iterable[tuple[float, float]]
+    ]
 
 MIN_RANDOM_POINTS = 10000
 
@@ -485,9 +489,6 @@ def _random_points_in_rectangle(
     return xy
 
 
-PointGenerator = Callable[
-    [np.random.RandomState, int, float, float], Iterable[tuple[float, float]]
-]
 _POINTS_GENERATORS: dict[Shape, PointGenerator] = {
     Shape.ELLIPSE: _random_points_in_ellipse,
     Shape.RECTANGLE: _random_points_in_rectangle,

--- a/src/useq/_plate.py
+++ b/src/useq/_plate.py
@@ -5,7 +5,6 @@ from contextlib import suppress
 from functools import cached_property
 from typing import (
     Any,
-    Callable,
     Iterable,
     List,
     Sequence,
@@ -375,71 +374,9 @@ class WellPlatePlan(FrozenModel, Sequence[Position]):
 
     def plot(self, show_axis: bool = True) -> None:
         """Plot the selected positions on the plate."""
-        import matplotlib.pyplot as plt
-        from matplotlib import patches
+        from useq._plot import plot_plate
 
-        _, ax = plt.subplots()
-
-        # hide axes
-        if not show_axis:
-            ax.axis("off")
-
-        # ################ draw outline of all wells ################
-        height, width = self.plate.well_size  # mm
-        height, width = height * 1000, width * 1000  # µm
-
-        kwargs = {}
-        offset_x, offset_y = 0.0, 0.0
-        if self.plate.circular_wells:
-            patch_type: Callable = patches.Ellipse
-        else:
-            patch_type = patches.Rectangle
-            offset_x, offset_y = -width / 2, -height / 2
-            kwargs["rotation_point"] = "center"
-
-        for well in self.all_well_positions:
-            sh = patch_type(
-                (well.x + offset_x, well.y + offset_y),  # type: ignore[operator]
-                width=width,
-                height=height,
-                angle=self.rotation or 0,
-                facecolor="none",
-                edgecolor="gray",
-                linewidth=0.5,
-                linestyle="--",
-                **kwargs,
-            )
-            ax.add_patch(sh)
-
-        ################ plot image positions ################
-        w, h = self.well_points_plan.fov_width, self.well_points_plan.fov_height
-
-        for img_point in self.image_positions:
-            x, y = float(img_point.x), float(img_point.y)  # type: ignore[arg-type] # µm
-            if w and h:
-                ax.add_patch(
-                    patches.Rectangle(
-                        (x - w / 2, y - h / 2),
-                        width=w,
-                        height=h,
-                        facecolor="magenta",
-                        edgecolor="gray",
-                        linewidth=0.5,
-                        alpha=0.5,
-                    )
-                )
-            else:
-                plt.plot(x, y, "mo", markersize=3, alpha=0.5)
-
-        # ################ draw names on used wells ################
-        offset_x, offset_y = -width / 2, -height / 2
-        for well in self.selected_well_positions:
-            x, y = float(well.x), float(well.y)  # type: ignore[arg-type]
-            # draw name next to spot
-            ax.text(x + offset_x, y - offset_y, well.name, fontsize=7)
-
-        ax.axis("equal")
-        plt.show()
+        plot_plate(self, show_axis=show_axis)
 
 
 def _index_to_row_name(index: int) -> str:

--- a/src/useq/_plot.py
+++ b/src/useq/_plot.py
@@ -17,12 +17,25 @@ if TYPE_CHECKING:
     from useq._position import PositionBase
 
 
-def plot_positions(positions: Iterable[PositionBase], ax: Axes | None = None): ...
+def plot_points(points: Iterable[PositionBase], ax: Axes | None = None) -> None:
+    """Plot a list of positions.
+
+    Can be used with any iterable of PositionBase objects.
+    """
+    if ax is None:
+        _, ax = plt.subplots()
+
+    x, y = zip(*[(point.x, point.y) for point in points])
+    ax.scatter(x, y)
+    ax.scatter(x[0], y[0], color="red")  # mark the first point
+    ax.plot(x, y, alpha=0.5, color="gray")  # connect the points
+    ax.axis("equal")
+    plt.show()
 
 
 def plot_plate(
     plate_plan: WellPlatePlan, show_axis: bool = True, ax: Axes | None = None
-):
+) -> None:
     if ax is None:
         _, ax = plt.subplots()
 

--- a/src/useq/_plot.py
+++ b/src/useq/_plot.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Iterable
+
+try:
+    import matplotlib.pyplot as plt
+    from matplotlib import patches
+except ImportError as e:
+    raise ImportError(
+        "Matplotlib is required for plotting functions.  Please install matplotlib."
+    ) from e
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
+    from useq._plate import WellPlatePlan
+    from useq._position import PositionBase
+
+
+def plot_positions(positions: Iterable[PositionBase], ax: Axes | None = None): ...
+
+
+def plot_plate(
+    plate_plan: WellPlatePlan, show_axis: bool = True, ax: Axes | None = None
+):
+    if ax is None:
+        _, ax = plt.subplots()
+
+    # hide axes
+    if not show_axis:
+        ax.axis("off")
+
+    # ################ draw outline of all wells ################
+    height, width = plate_plan.plate.well_size  # mm
+    height, width = height * 1000, width * 1000  # µm
+
+    kwargs = {}
+    offset_x, offset_y = 0.0, 0.0
+    if plate_plan.plate.circular_wells:
+        patch_type: Callable = patches.Ellipse
+    else:
+        patch_type = patches.Rectangle
+        offset_x, offset_y = -width / 2, -height / 2
+        kwargs["rotation_point"] = "center"
+
+    for well in plate_plan.all_well_positions:
+        sh = patch_type(
+            (well.x + offset_x, well.y + offset_y),  # type: ignore[operator]
+            width=width,
+            height=height,
+            angle=plate_plan.rotation or 0,
+            facecolor="none",
+            edgecolor="gray",
+            linewidth=0.5,
+            linestyle="--",
+            **kwargs,
+        )
+        ax.add_patch(sh)
+
+    ################ plot image positions ################
+    w, h = plate_plan.well_points_plan.fov_width, plate_plan.well_points_plan.fov_height
+
+    for img_point in plate_plan.image_positions:
+        x, y = float(img_point.x), float(img_point.y)  # type: ignore[arg-type] # µm
+        if w and h:
+            ax.add_patch(
+                patches.Rectangle(
+                    (x - w / 2, y - h / 2),
+                    width=w,
+                    height=h,
+                    facecolor="magenta",
+                    edgecolor="gray",
+                    linewidth=0.5,
+                    alpha=0.5,
+                )
+            )
+        else:
+            plt.plot(x, y, "mo", markersize=3, alpha=0.5)
+
+    # ################ draw names on used wells ################
+    offset_x, offset_y = -width / 2, -height / 2
+    for well in plate_plan.selected_well_positions:
+        x, y = float(well.x), float(well.y)  # type: ignore[arg-type]
+        # draw name next to spot
+        ax.text(x + offset_x, y - offset_y, well.name, fontsize=7)
+
+    ax.axis("equal")
+    plt.show()

--- a/src/useq/_point_visiting.py
+++ b/src/useq/_point_visiting.py
@@ -1,0 +1,219 @@
+from enum import Enum
+from functools import partial
+from typing import Callable, Iterator, Tuple
+
+import numpy as np
+
+# ----------------------------- Random Points -----------------------------------
+
+
+class GridOrder(Enum):
+    """Order in which grid positions will be iterated.
+
+    Attributes
+    ----------
+    row_wise : Literal['row_wise']
+        Iterate row by row.
+    column_wise : Literal['column_wise']
+        Iterate column by column.
+    row_wise_snake : Literal['row_wise_snake']
+        Iterate row by row, but alternate the direction of the columns.
+    column_wise_snake : Literal['column_wise_snake']
+        Iterate column by column, but alternate the direction of the rows.
+    spiral : Literal['spiral']
+        Iterate in a spiral pattern, starting from the center.
+    """
+
+    row_wise = "row_wise"
+    column_wise = "column_wise"
+    row_wise_snake = "row_wise_snake"
+    column_wise_snake = "column_wise_snake"
+    spiral = "spiral"
+
+    def generate_indices(self, rows: int, columns: int) -> Iterator[Tuple[int, int]]:
+        """Generate indices for the given grid size."""
+        return _INDEX_GENERATORS[self](rows, columns)
+
+
+def _spiral_indices(
+    rows: int, columns: int, center_origin: bool = False
+) -> Iterator[Tuple[int, int]]:
+    """Return a spiral iterator over a 2D grid.
+
+    Parameters
+    ----------
+    rows : int
+        Number of rows.
+    columns : int
+        Number of columns.
+    center_origin : bool
+        If center_origin is True, all indices are centered around (0, 0), and some will
+        be negative. Otherwise, the indices are centered around (rows//2, columns//2)
+
+    Yields
+    ------
+    (x, y) : tuple[int, int]
+        Indices of the next element in the spiral.
+    """
+    # direction: first down and then clockwise (assuming positive Y is down)
+
+    x = y = 0
+    if center_origin:  # see docstring
+        xshift = yshift = 0
+    else:
+        xshift = (columns - 1) // 2
+        yshift = (rows - 1) // 2
+    dx = 0
+    dy = -1
+    for _ in range(max(columns, rows) ** 2):
+        if (-columns / 2 < x <= columns / 2) and (-rows / 2 < y <= rows / 2):
+            yield y + yshift, x + xshift
+        if x == y or (x < 0 and x == -y) or (x > 0 and x == 1 - y):
+            dx, dy = -dy, dx
+        x, y = x + dx, y + dy
+
+
+# function that iterates indices (row, col) in a grid where (0, 0) is the top left
+def _rect_indices(
+    rows: int, columns: int, snake: bool = False, row_wise: bool = True
+) -> Iterator[Tuple[int, int]]:
+    """Return a row or column-wise iterator over a 2D grid."""
+    c, r = np.meshgrid(np.arange(columns), np.arange(rows))
+    if snake:
+        if row_wise:
+            c[1::2, :] = c[1::2, :][:, ::-1]
+        else:
+            r[:, 1::2] = r[:, 1::2][::-1, :]
+    return zip(r.ravel(), c.ravel()) if row_wise else zip(r.T.ravel(), c.T.ravel())
+
+
+IndexGenerator = Callable[[int, int], Iterator[Tuple[int, int]]]
+_INDEX_GENERATORS: dict[GridOrder, IndexGenerator] = {
+    GridOrder.row_wise: partial(_rect_indices, snake=False, row_wise=True),
+    GridOrder.column_wise: partial(_rect_indices, snake=False, row_wise=False),
+    GridOrder.row_wise_snake: partial(_rect_indices, snake=True, row_wise=True),
+    GridOrder.column_wise_snake: partial(_rect_indices, snake=True, row_wise=False),
+    GridOrder.spiral: _spiral_indices,
+}
+
+# ----------------------------- Random Points -----------------------------------
+
+
+class TraversalOrder(Enum):
+    NEAREST_NEIGHBOR = "Nearest Neighbor"
+    SHORTEST_TOUR = "Shortest Tour (TSP)"
+    RANDOM_WALK = "Random Walk"
+    SPIRAL = "Spiral Traversal"
+
+    def sort_points(self, points: np.ndarray) -> np.ndarray:
+        """Sort the points based on the traversal order."""
+        if self == TraversalOrder.NEAREST_NEIGHBOR:
+            return _nearest_neighbor_order(points)
+        if self == TraversalOrder.SHORTEST_TOUR:
+            return _shortest_tour_order(points)
+        if self == TraversalOrder.RANDOM_WALK:
+            return _random_walk_sort(points)
+        if self == TraversalOrder.SPIRAL:
+            return _spiral_sort(points)
+        raise ValueError(f"Unknown traversal order: {self}")
+
+
+LARGE_NUMBER = 1e9
+
+
+def _nearest_neighbor_order(points: np.ndarray, start_at: int = 0) -> np.ndarray:
+    """Return the order of points based on the nearest neighbor algorithm.
+
+    Parameters.
+    ----------
+    points : np.ndarray
+        Array of 2D (Y, X) points in the format (n, 2).
+    start_at : int, optional
+        Index of the point to start at. If None, the first point is used.
+
+    Examples
+    --------
+    >>> points = np.array([[0, 0], [1, 0], [1, 1], [0, 1]])
+    >>> order = _nearest_neighbor_order(points)
+    >>> sorted = points[order]
+    """
+    n = len(points)
+    visited = np.zeros(n, dtype=bool)
+    order = np.zeros(n, dtype=int)
+    order[0] = start_at
+    visited[start_at] = True
+
+    # NOTE: > ~500 of points, scipy.spatial.cKDTree would begin to be faster
+    # but it's a new dependency and may not be a common use case
+    for i in range(1, n):
+        # get the last point
+        last = points[order[i - 1]]
+        # calculate the distance to all other points
+        dist = np.linalg.norm(points - last, axis=1)
+        # find the nearest point that has not been visited
+        next_point = np.argmin(dist + visited * LARGE_NUMBER)
+        # store the index of the next point
+        order[i] = next_point
+        # mark the point as visited
+        visited[next_point] = True
+
+    return order  # type: ignore [no-any-return]
+
+
+def _shortest_tour_order(points: np.ndarray, start_at: int = 0) -> np.ndarray:
+    """Return the order of points based on the shortest tour (TSP).
+
+    Parameters.
+    ----------
+    points : np.ndarray
+        Array of 2D (Y, X) points in the format (n, 2).
+    start_at : int, optional
+        Index of the point to start at. If None, the first point is used.
+    """
+    raise NotImplementedError("Shortest tour is not implemented yet.")
+
+
+
+
+
+def _path_distance(r: np.ndarray, c: np.ndarray) -> float:
+    # Calculate the euclidian distance in n-space of the route r traversing cities c,
+    # ending at the path start.
+    return np.sum([np.linalg.norm(c[r[p]] - c[r[p - 1]]) for p in range(len(r))])
+
+
+def _two_opt_swap(r: np.ndarray, i: int, k: int) -> np.ndarray:
+    # Reverse the order of all elements from element i to element k in array r.
+    return np.concatenate((r[0:i], r[k : -len(r) + i - 1 : -1], r[k + 1 : len(r)]))
+
+
+def two_opt(points: np.ndarray, improvement_threshold: float = 0.01) -> np.ndarray:
+    # 2-opt Algorithm adapted from https://en.wikipedia.org/wiki/2-opt
+    # https://stackoverflow.com/questions/25585401/travelling-salesman-in-scipy
+    # Make an array of row numbers corresponding to cities.
+    route = np.arange(points.shape[0])
+    # Initialize the improvement factor.
+    improvement_factor = 1.0
+    # Calculate the distance of the initial path.
+    best_distance = _path_distance(route, points)
+    # If the route is still improving, keep going!
+    while improvement_factor > improvement_threshold:
+        # Record the distance at the beginning of the loop.
+        distance_to_beat = best_distance
+        # From each city except the first and last,
+        for swap_first in range(1, len(route) - 2):
+            # to each of the points following,
+            for swap_last in range(swap_first + 1, len(route)):
+                # try reversing the order of these points
+                new_route = _two_opt_swap(route, swap_first, swap_last)
+                # and check the total distance with this modification.
+                new_distance = _path_distance(new_route, points)
+                # If the path distance is an improvement,
+                if new_distance < best_distance:
+                    # make this the accepted best route
+                    route = new_route
+                    # and update the distance corresponding to this route.
+                    best_distance = new_distance
+        # Calculate how much the route has improved.
+        improvement_factor = 1 - best_distance / distance_to_beat
+    return route  # When the route is no longer improving substan

--- a/src/useq/_point_visiting.py
+++ b/src/useq/_point_visiting.py
@@ -173,9 +173,6 @@ def _shortest_tour_order(points: np.ndarray, start_at: int = 0) -> np.ndarray:
     raise NotImplementedError("Shortest tour is not implemented yet.")
 
 
-
-
-
 def _path_distance(r: np.ndarray, c: np.ndarray) -> float:
     # Calculate the euclidian distance in n-space of the route r traversing cities c,
     # ending at the path start.

--- a/src/useq/_point_visiting.py
+++ b/src/useq/_point_visiting.py
@@ -113,7 +113,7 @@ class TraversalOrder(Enum):
             return _two_opt_order(points, start_at)
         if self == TraversalOrder.RANDOM:
             return np.random.permutation(len(points))
-        raise ValueError(f"Unknown traversal order: {self}")
+        raise ValueError(f"Unknown traversal order: {self}")  # pragma: no cover
 
     def __call__(
         self, points: Iterable[tuple[float, float]], start_at: int = 0

--- a/src/useq/_point_visiting.py
+++ b/src/useq/_point_visiting.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 from functools import partial
 from typing import Callable, Iterable, Iterator, Tuple

--- a/src/useq/_point_visiting.py
+++ b/src/useq/_point_visiting.py
@@ -7,7 +7,7 @@ import numpy as np
 # ----------------------------- Random Points -----------------------------------
 
 
-class GridOrder(Enum):
+class OrderMode(Enum):
     """Order in which grid positions will be iterated.
 
     Attributes
@@ -88,12 +88,12 @@ def _rect_indices(
 
 
 IndexGenerator = Callable[[int, int], Iterator[Tuple[int, int]]]
-_INDEX_GENERATORS: dict[GridOrder, IndexGenerator] = {
-    GridOrder.row_wise: partial(_rect_indices, snake=False, row_wise=True),
-    GridOrder.column_wise: partial(_rect_indices, snake=False, row_wise=False),
-    GridOrder.row_wise_snake: partial(_rect_indices, snake=True, row_wise=True),
-    GridOrder.column_wise_snake: partial(_rect_indices, snake=True, row_wise=False),
-    GridOrder.spiral: _spiral_indices,
+_INDEX_GENERATORS: dict[OrderMode, IndexGenerator] = {
+    OrderMode.row_wise: partial(_rect_indices, snake=False, row_wise=True),
+    OrderMode.column_wise: partial(_rect_indices, snake=False, row_wise=False),
+    OrderMode.row_wise_snake: partial(_rect_indices, snake=True, row_wise=True),
+    OrderMode.column_wise_snake: partial(_rect_indices, snake=True, row_wise=False),
+    OrderMode.spiral: _spiral_indices,
 }
 
 # ----------------------------- Random Points -----------------------------------

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -100,6 +100,12 @@ class _MultiPointPlan(MutableModel, Generic[PositionT]):
     def num_positions(self) -> int:
         raise NotImplementedError("This method must be implemented by subclasses.")
 
+    def plot(self) -> None:
+        """Plot the positions in the plan."""
+        from useq._plot import plot_points
+
+        plot_points(self)
+
 
 class RelativePosition(PositionBase, _MultiPointPlan["RelativePosition"]):
     """A relative position in 3D space.

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -12,7 +12,7 @@ from useq import (
     RelativeMultiPointPlan,
     RelativePosition,
 )
-from useq._grid import OrderMode, _rect_indices, _spiral_indices
+from useq._point_visiting import GridOrder, _rect_indices, _spiral_indices
 
 if TYPE_CHECKING:
     from useq._position import PositionBase
@@ -60,19 +60,19 @@ def test_position_equality():
         """Create a set of tuples of GridPosition attributes excluding 'name'"""
         return {(pos.x, pos.y, pos.is_relative) for pos in positions}
 
-    t1 = GridRowsColumns(rows=3, columns=3, mode=OrderMode.spiral)
+    t1 = GridRowsColumns(rows=3, columns=3, mode=GridOrder.spiral)
     spiral_pos = positions_without_name(t1.iter_grid_positions(1, 1))
 
-    t2 = GridRowsColumns(rows=3, columns=3, mode=OrderMode.row_wise)
+    t2 = GridRowsColumns(rows=3, columns=3, mode=GridOrder.row_wise)
     row_pos = positions_without_name(t2.iter_grid_positions(1, 1))
 
     t3 = GridRowsColumns(rows=3, columns=3, mode="row_wise_snake")
     snake_row_pos = positions_without_name(t3.iter_grid_positions(1, 1))
 
-    t4 = GridRowsColumns(rows=3, columns=3, mode=OrderMode.column_wise)
+    t4 = GridRowsColumns(rows=3, columns=3, mode=GridOrder.column_wise)
     col_pos = positions_without_name(t4.iter_grid_positions(1, 1))
 
-    t5 = GridRowsColumns(rows=3, columns=3, mode=OrderMode.column_wise_snake)
+    t5 = GridRowsColumns(rows=3, columns=3, mode=GridOrder.column_wise_snake)
     snake_col_pos = positions_without_name(t5.iter_grid_positions(1, 1))
 
     assert spiral_pos == row_pos == snake_row_pos == col_pos == snake_col_pos

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -126,7 +126,7 @@ def test_num_position_error() -> None:
 
 
 expected_rectangle = [(0.2, 1.1), (0.4, 0.2), (-0.3, 0.7)]
-expected_ellipse = [(-0.0, -2.1), (0.7, 1.7), (-1.0, 1.3)]
+expected_ellipse = [(-0.9, -1.1), (0.9, -0.5), (-0.8, -0.4)]
 
 
 @pytest.mark.parametrize("n_points", [3, 100])

--- a/tests/test_points_plans.py
+++ b/tests/test_points_plans.py
@@ -13,7 +13,7 @@ from useq import (
     RelativePosition,
     TraversalOrder,
 )
-from useq._point_visiting import GridOrder, _rect_indices, _spiral_indices
+from useq._point_visiting import OrderMode, _rect_indices, _spiral_indices
 
 if TYPE_CHECKING:
     from useq._position import PositionBase
@@ -61,19 +61,19 @@ def test_position_equality():
         """Create a set of tuples of GridPosition attributes excluding 'name'"""
         return {(pos.x, pos.y, pos.is_relative) for pos in positions}
 
-    t1 = GridRowsColumns(rows=3, columns=3, mode=GridOrder.spiral)
+    t1 = GridRowsColumns(rows=3, columns=3, mode=OrderMode.spiral)
     spiral_pos = positions_without_name(t1.iter_grid_positions(1, 1))
 
-    t2 = GridRowsColumns(rows=3, columns=3, mode=GridOrder.row_wise)
+    t2 = GridRowsColumns(rows=3, columns=3, mode=OrderMode.row_wise)
     row_pos = positions_without_name(t2.iter_grid_positions(1, 1))
 
     t3 = GridRowsColumns(rows=3, columns=3, mode="row_wise_snake")
     snake_row_pos = positions_without_name(t3.iter_grid_positions(1, 1))
 
-    t4 = GridRowsColumns(rows=3, columns=3, mode=GridOrder.column_wise)
+    t4 = GridRowsColumns(rows=3, columns=3, mode=OrderMode.column_wise)
     col_pos = positions_without_name(t4.iter_grid_positions(1, 1))
 
-    t5 = GridRowsColumns(rows=3, columns=3, mode=GridOrder.column_wise_snake)
+    t5 = GridRowsColumns(rows=3, columns=3, mode=OrderMode.column_wise_snake)
     snake_col_pos = positions_without_name(t5.iter_grid_positions(1, 1))
 
     assert spiral_pos == row_pos == snake_row_pos == col_pos == snake_col_pos

--- a/tests/test_points_plans.py
+++ b/tests/test_points_plans.py
@@ -11,6 +11,7 @@ from useq import (
     RandomPoints,
     RelativeMultiPointPlan,
     RelativePosition,
+    TraversalOrder,
 )
 from useq._point_visiting import GridOrder, _rect_indices, _spiral_indices
 
@@ -156,6 +157,22 @@ def test_random_points(n_points: int, shape: str, seed: Optional[int]) -> None:
             list(rp)
 
 
+@pytest.mark.parametrize("order", list(TraversalOrder))
+def test_traversal(order: TraversalOrder):
+    pp = RandomPoints(
+        num_points=30,
+        max_height=3000,
+        max_width=3000,
+        order=order,
+        random_seed=1,
+        start_at=10,
+        fov_height=300,
+        fov_width=300,
+        allow_overlap=False,
+    )
+    list(pp)
+
+
 fov = {"fov_height": 200, "fov_width": 200}
 
 
@@ -168,7 +185,12 @@ fov = {"fov_height": 200, "fov_width": 200}
         RelativePosition(**fov),
     ],
 )
-def test_points_plans(obj: RelativeMultiPointPlan):
+def test_points_plans(obj: RelativeMultiPointPlan, monkeypatch: pytest.MonkeyPatch):
+    mpl = pytest.importorskip("matplotlib.pyplot")
+    monkeypatch.setattr(mpl, "show", lambda: None)
+
     assert isinstance(obj, get_args(RelativeMultiPointPlan))
     assert all(isinstance(x, RelativePosition) for x in obj)
     assert isinstance(obj.num_positions(), int)
+
+    obj.plot()

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -116,9 +116,9 @@ g_inputs = [
             random_seed=0,
         ),
         [
-            RelativePosition(x=-0.0, y=-2.1, name="0000"),
-            RelativePosition(x=0.7, y=1.7, name="0001"),
-            RelativePosition(x=-1.0, y=1.3, name="0002"),
+            RelativePosition(x=-0.9, y=-1.1, name="0000"),
+            RelativePosition(x=0.9, y=-0.5, name="0001"),
+            RelativePosition(x=-0.8, y=-0.4, name="0002"),
         ],
     ),
 ]


### PR DESCRIPTION
adds 

- useq.TraversalOrder - to dictate how random points are traversed
- addes a nearest neighbor and  2-opt algorithm, (for slightly better path choosing)
- allows you to specify the starting index
- adds plotting to all points plans:



```python
import useq

pp = useq.RandomPoints(
    num_points=100,
    max_height=6000,
    max_width=6000,
    order=useq.TraversalOrder.TWO_OPT,
    random_seed=1,
    shape="rectangle",
    start_at=10,
    fov_height=300,
    fov_width=300,
    allow_overlap=False,
)
pp.plot()

```

two-opt:

<img width="752" alt="Screenshot 2024-07-08 at 4 01 09 PM" src="https://github.com/pymmcore-plus/useq-schema/assets/1609449/b2912cd8-8eab-47b1-ad64-e14921cc18c2">


nearest neighbor:
<img width="752" alt="Screenshot 2024-07-08 at 4 01 34 PM" src="https://github.com/pymmcore-plus/useq-schema/assets/1609449/4694d293-8d67-4dd0-98a2-59ae800909ad">
