### PR TITLE
fix: fix pydantic smart union in older versions, and add minreqs test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             python-version: "3.8"
 
   test-minreqs:
-    uses: pyapp-kit/workflows/.github/workflows/test-pyrepo.yml@v2
+    uses: pyapp-kit/workflows/.github/workflows/test-pyrepo.yml@main
     with:
       os: ubuntu-latest
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,21 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.8"
 
+  test-minreqs:
+    uses: pyapp-kit/workflows/.github/workflows/test-pyrepo.yml@v2
+    with:
+      os: ubuntu-latest
+      python-version: ${{ matrix.python-version }}
+      pip-install-min-reqs: true
+      coverage-upload: artifact
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.12"]
+
   upload_coverage:
     if: always()
-    needs: [test]
+    needs: [test, test-minreqs]
     uses: pyapp-kit/workflows/.github/workflows/upload-coverage.yml@v2
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = ["pydantic >=2,!=2.4.1", "numpy", "typing-extensions"]
+dependencies = ["pydantic >=2.2,!=2.4.1", "numpy", "typing-extensions"]
 
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = ["pydantic >=2.2,!=2.4.1", "numpy", "typing-extensions"]
+dependencies = ["pydantic >=2.6", "numpy", "typing-extensions"]
 
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -184,7 +184,9 @@ class MDASequence(UseqModel):
     stage_positions: Union[WellPlatePlan, Tuple[Position, ...]] = Field(
         default_factory=tuple
     )
-    grid_plan: Optional[MultiPointPlan] = None
+    grid_plan: Optional[MultiPointPlan] = Field(
+        default=None, union_mode="left_to_right"
+    )
     channels: Tuple[Channel, ...] = Field(default_factory=tuple)
     time_plan: Optional[AnyTimePlan] = None
     z_plan: Optional[AnyZPlan] = None


### PR DESCRIPTION
found an issue with the smart union on `MDASequnce.grid_plan: MultiPointPlan` ... @fdrgsp, this may be related to the bug you were seeing ... but not sure.  it was working only on pydantic 2.8+
this should fix back to 2.2, and adds a tests for that 