### PR TITLE
feat: allow start_at to be a point

### DIFF
--- a/src/useq/_base_model.py
+++ b/src/useq/_base_model.py
@@ -55,7 +55,9 @@ class _ReplaceableModel(BaseModel):
         assumes that all objects are valid and will not perform any validation or
         casting.
         """
-        return type(self).model_validate({**self.model_dump(exclude={"uid"}), **kwargs})
+        # only get values for top level fields
+        d = {k: getattr(self, k) for k in self.model_fields if k != "uid"}
+        return type(self).model_validate({**d, **kwargs})
 
     def __repr_args__(self) -> "ReprArgs":
         """Only show fields that are not None or equal to their default value."""


### PR DESCRIPTION
this allows the start_at field of RandomPoints to be an actual position, with semantics:

```
    start_at : int | RelativePosition
        Position or index of the point to start at. This is only used if `order` is
        'nearest_neighbor' or 'two_opt'.  If a position is provided, it will *always*
        be included in the list of points. If an index is provided, it must be less than
        the number of points, and corresponds to the index of the (randomly generated)
        points; this likely only makes sense when `random_seed` is provided.
```