### PR TITLE
refactor: normalize `WellPlate.selected_wells`

### DIFF
--- a/src/useq/_plate.py
+++ b/src/useq/_plate.py
@@ -226,7 +226,15 @@ class WellPlatePlan(FrozenModel, Sequence[Position]):
 
         if isinstance(value, list):
             value = tuple(value)
-        return handler(plate.indices(value))  # type: ignore [no-any-return]
+        try:
+            selected = plate.indices(value)
+        except (TypeError, IndexError) as e:
+            raise ValueError(
+                f"Invalid well selection {value!r} for plate of "
+                f"shape {plate.shape}: {e}"
+            ) from e
+
+        return handler(selected)  # type: ignore [no-any-return]
 
     @property
     def rotation_matrix(self) -> np.ndarray:

--- a/tests/test_well_plate.py
+++ b/tests/test_well_plate.py
@@ -134,3 +134,23 @@ def test_plate_plan_equality() -> None:
     pp3 = useq.WellPlatePlan.model_validate_json(pp.model_dump_json())
 
     assert pp == pp2 == pp3
+
+
+def test_plate_repr() -> None:
+    # both can be reduced
+    pp = useq.WellPlatePlan(
+        plate=96, a1_center_xy=(0, 0), selected_wells=np.s_[1:5, 3:12:2]
+    )
+    assert "selected_wells=(slice(1, 5), slice(3, 12, 2))" in repr(pp)
+
+    # can't be reduced
+    pp = useq.WellPlatePlan(
+        plate=96, a1_center_xy=(0, 0), selected_wells=[(1, 1, 1, 2), (7, 3, 4, 2)]
+    )
+    assert "selected_wells=((1, 1, 1, 2), (7, 3, 4, 2))" in repr(pp)
+
+    # one can be reduced
+    pp = useq.WellPlatePlan(
+        plate=96, a1_center_xy=(0, 0), selected_wells=np.s_[(1, 2, 2, 3), 1:5]
+    )
+    assert "selected_wells=((1, 2, 2, 3), slice(1, 5))" in repr(pp)

--- a/tests/test_well_plate.py
+++ b/tests/test_well_plate.py
@@ -130,5 +130,6 @@ def test_plate_plan_equality() -> None:
         a1_center_xy=(0, 0),
         selected_wells=[(1, 1, 3, 3), (0, 3, 0, 3)],
     )
+    pp3 = useq.WellPlatePlan.model_validate_json(pp.model_dump_json())
 
-    assert pp == pp2
+    assert pp == pp2 == pp3

--- a/tests/test_well_plate.py
+++ b/tests/test_well_plate.py
@@ -122,6 +122,7 @@ def test_plate_plan_position_order() -> None:
 
 
 def test_plate_plan_equality() -> None:
+    """Various ways of selecting wells should result in the same plan."""
     pp = useq.WellPlatePlan(
         plate=96, a1_center_xy=(0, 0), selected_wells=np.s_[1:5:2, :6:3]
     )

--- a/tests/test_well_plate.py
+++ b/tests/test_well_plate.py
@@ -141,16 +141,22 @@ def test_plate_repr() -> None:
     pp = useq.WellPlatePlan(
         plate=96, a1_center_xy=(0, 0), selected_wells=np.s_[1:5, 3:12:2]
     )
-    assert "selected_wells=(slice(1, 5), slice(3, 12, 2))" in repr(pp)
+    rpp = repr(pp)
+    assert "selected_wells=(slice(1, 5), slice(3, 12, 2))" in rpp
+    assert eval(rpp, vars(useq)) == pp  # noqa: S307
 
     # can't be reduced
     pp = useq.WellPlatePlan(
         plate=96, a1_center_xy=(0, 0), selected_wells=[(1, 1, 1, 2), (7, 3, 4, 2)]
     )
-    assert "selected_wells=((1, 1, 1, 2), (7, 3, 4, 2))" in repr(pp)
+    rpp = repr(pp)
+    assert "selected_wells=((1, 1, 1, 2), (7, 3, 4, 2))" in rpp
+    assert eval(rpp, vars(useq)) == pp  # noqa: S307
 
     # one can be reduced
     pp = useq.WellPlatePlan(
         plate=96, a1_center_xy=(0, 0), selected_wells=np.s_[(1, 2, 2, 3), 1:5]
     )
-    assert "selected_wells=((1, 2, 2, 3), slice(1, 5))" in repr(pp)
+    rpp = repr(pp)
+    assert "selected_wells=((1, 2, 2, 3), slice(1, 5))" in rpp
+    assert eval(rpp, vars(useq)) == pp  # noqa: S307

--- a/tests/test_well_plate.py
+++ b/tests/test_well_plate.py
@@ -119,3 +119,16 @@ def test_plate_plan_position_order() -> None:
     for i in range(0, len(names), 3):
         chunk = names[i : i + 3]
         assert len(set(chunk)) == 1, f"Chunk {chunk} does not have the same elements"
+
+
+def test_plate_plan_equality() -> None:
+    pp = useq.WellPlatePlan(
+        plate=96, a1_center_xy=(0, 0), selected_wells=np.s_[1:5:2, :6:3]
+    )
+    pp2 = useq.WellPlatePlan(
+        plate="96-well",
+        a1_center_xy=(0, 0),
+        selected_wells=[(1, 1, 3, 3), (0, 3, 0, 3)],
+    )
+
+    assert pp == pp2


### PR DESCRIPTION
This PR changes the two of `WellPlate.selected_wells` from the very lax IndexExpression

```python
Index = Union[int, List[int], Annotated[slice, _SliceType]]
IndexExpression = Union[Tuple[Index, ...], Index]
```

to a strict:

```python
Tuple[Tuple[int, ...], Tuple[int, ...]]
```

The primary reason is that it makes checking equality between two plate plans easier.

it also modifies `__repr_args__` to simplify the representation when possible