### PR TITLE
fix: reset_event_timer defaults to True in sub-sequences

### DIFF
--- a/src/useq/_iter_sequence.py
+++ b/src/useq/_iter_sequence.py
@@ -150,8 +150,7 @@ def _iter_sequence(
         if not item:  # the case with no events
             continue  # pragma: no cover
         # get axes objects for this event
-        index, time, position, grid, channel, z_pos = _parse_axes(
-            zip(order, item))
+        index, time, position, grid, channel, z_pos = _parse_axes(zip(order, item))
 
         # skip if necessary
         if _should_skip(position, channel, index, sequence.z_plan):
@@ -165,8 +164,7 @@ def _iter_sequence(
             {**event_kwargs.get("index", {}), **index}  # type: ignore
         )
         # determine x, y, z positions
-        event_kwargs.update(
-            _xyzpos(position, channel, sequence.z_plan, grid, z_pos))
+        event_kwargs.update(_xyzpos(position, channel, sequence.z_plan, grid, z_pos))
         if position and position.name:
             event_kwargs["pos_name"] = position.name
         if channel:
@@ -199,7 +197,7 @@ def _iter_sequence(
                 _pos, _offsets = _position_offsets(position, event_kwargs)
                 # build overrides for this position
                 pos_overrides = MDAEventDict(sequence=sequence, **_pos)
-                pos_overrides['reset_event_timer'] = False
+                pos_overrides["reset_event_timer"] = False
                 if position.name:
                     pos_overrides["pos_name"] = position.name
 

--- a/src/useq/_iter_sequence.py
+++ b/src/useq/_iter_sequence.py
@@ -150,7 +150,8 @@ def _iter_sequence(
         if not item:  # the case with no events
             continue  # pragma: no cover
         # get axes objects for this event
-        index, time, position, grid, channel, z_pos = _parse_axes(zip(order, item))
+        index, time, position, grid, channel, z_pos = _parse_axes(
+            zip(order, item))
 
         # skip if necessary
         if _should_skip(position, channel, index, sequence.z_plan):
@@ -164,7 +165,8 @@ def _iter_sequence(
             {**event_kwargs.get("index", {}), **index}  # type: ignore
         )
         # determine x, y, z positions
-        event_kwargs.update(_xyzpos(position, channel, sequence.z_plan, grid, z_pos))
+        event_kwargs.update(
+            _xyzpos(position, channel, sequence.z_plan, grid, z_pos))
         if position and position.name:
             event_kwargs["pos_name"] = position.name
         if channel:
@@ -197,6 +199,7 @@ def _iter_sequence(
                 _pos, _offsets = _position_offsets(position, event_kwargs)
                 # build overrides for this position
                 pos_overrides = MDAEventDict(sequence=sequence, **_pos)
+                pos_overrides['reset_event_timer'] = False
                 if position.name:
                     pos_overrides["pos_name"] = position.name
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -64,8 +64,7 @@ t_as_dict: _T = [
         [{"loops": 5, "interval": 0.25}, {"interval": 1, "duration": 4}],
         [0, 0.25, 0.50, 0.75, 1, 2, 3, 4, 5],
     ),
-    ({"loops": 5, "duration": {"milliseconds": 8}},
-     [0, 0.002, 0.004, 0.006, 0.008]),
+    ({"loops": 5, "duration": {"milliseconds": 8}}, [0, 0.002, 0.004, 0.006, 0.008]),
     ({"loops": 5, "duration": {"seconds": 8}}, [0, 2, 4, 6, 8]),
 ]
 t_inputs = t_as_class + t_as_dict
@@ -290,8 +289,7 @@ def test_combinations(
     pexpectation: Sequence[float],
 ) -> None:
     mda = MDASequence(
-        time_plan=tplan, z_plan=zplan, channels=[
-            channel], stage_positions=positions
+        time_plan=tplan, z_plan=zplan, channels=[channel], stage_positions=positions
     )
 
     assert list(mda.z_plan) == zexpectation
@@ -309,8 +307,7 @@ def test_schema(cls: BaseModel) -> None:
 
 
 def test_z_position() -> None:
-    mda = MDASequence(axis_order="tpcz", stage_positions=[
-                      (222, 1, 10), (111, 1, 20)])
+    mda = MDASequence(axis_order="tpcz", stage_positions=[(222, 1, 10), (111, 1, 20)])
     assert not mda.z_plan
     for event in mda:
         assert event.z_pos
@@ -355,8 +352,7 @@ def test_skip_channel_do_stack_no_zplan() -> None:
 
 def test_event_action_union() -> None:
     # test that action unions work
-    MDAEvent(action={"autofocus_device_name": "Z",
-             "autofocus_motor_offset": 25})
+    MDAEvent(action={"autofocus_device_name": "Z", "autofocus_motor_offset": 25})
 
 
 def test_keep_shutter_open() -> None:
@@ -443,12 +439,22 @@ def test_reset_event_timer() -> None:
 
     events = list(
         MDASequence(
-            stage_positions=[Position(x=0, y=0,
-                                      sequence=MDASequence(channels=["Cy5"],
-                                                           time_plan={"interval": 1, "loops": 2})),
-                             Position(x=1, y=1,
-                                      sequence=MDASequence(channels=["DAPI"],
-                                                           time_plan={"interval": 1, "loops": 2}))]
+            stage_positions=[
+                Position(
+                    x=0,
+                    y=0,
+                    sequence=MDASequence(
+                        channels=["Cy5"], time_plan={"interval": 1, "loops": 2}
+                    ),
+                ),
+                Position(
+                    x=1,
+                    y=1,
+                    sequence=MDASequence(
+                        channels=["DAPI"], time_plan={"interval": 1, "loops": 2}
+                    ),
+                ),
+            ]
         )
     )
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -64,7 +64,8 @@ t_as_dict: _T = [
         [{"loops": 5, "interval": 0.25}, {"interval": 1, "duration": 4}],
         [0, 0.25, 0.50, 0.75, 1, 2, 3, 4, 5],
     ),
-    ({"loops": 5, "duration": {"milliseconds": 8}}, [0, 0.002, 0.004, 0.006, 0.008]),
+    ({"loops": 5, "duration": {"milliseconds": 8}},
+     [0, 0.002, 0.004, 0.006, 0.008]),
     ({"loops": 5, "duration": {"seconds": 8}}, [0, 2, 4, 6, 8]),
 ]
 t_inputs = t_as_class + t_as_dict
@@ -289,7 +290,8 @@ def test_combinations(
     pexpectation: Sequence[float],
 ) -> None:
     mda = MDASequence(
-        time_plan=tplan, z_plan=zplan, channels=[channel], stage_positions=positions
+        time_plan=tplan, z_plan=zplan, channels=[
+            channel], stage_positions=positions
     )
 
     assert list(mda.z_plan) == zexpectation
@@ -307,7 +309,8 @@ def test_schema(cls: BaseModel) -> None:
 
 
 def test_z_position() -> None:
-    mda = MDASequence(axis_order="tpcz", stage_positions=[(222, 1, 10), (111, 1, 20)])
+    mda = MDASequence(axis_order="tpcz", stage_positions=[
+                      (222, 1, 10), (111, 1, 20)])
     assert not mda.z_plan
     for event in mda:
         assert event.z_pos
@@ -352,7 +355,8 @@ def test_skip_channel_do_stack_no_zplan() -> None:
 
 def test_event_action_union() -> None:
     # test that action unions work
-    MDAEvent(action={"autofocus_device_name": "Z", "autofocus_motor_offset": 25})
+    MDAEvent(action={"autofocus_device_name": "Z",
+             "autofocus_motor_offset": 25})
 
 
 def test_keep_shutter_open() -> None:
@@ -432,6 +436,22 @@ def test_reset_event_timer() -> None:
             axis_order="ptgcz",
         )
     )
+    assert events[0].reset_event_timer
+    assert not events[1].reset_event_timer
+    assert events[2].reset_event_timer
+    assert not events[3].reset_event_timer
+
+    events = list(
+        MDASequence(
+            stage_positions=[Position(x=0, y=0,
+                                      sequence=MDASequence(channels=["Cy5"],
+                                                           time_plan={"interval": 1, "loops": 2})),
+                             Position(x=1, y=1,
+                                      sequence=MDASequence(channels=["DAPI"],
+                                                           time_plan={"interval": 1, "loops": 2}))]
+        )
+    )
+
     assert events[0].reset_event_timer
     assert not events[1].reset_event_timer
     assert events[2].reset_event_timer


### PR DESCRIPTION
Fixes problem mentioned in #187. All events in sub-sequences had the reset_event_timer flag set to True.
https://github.com/pymmcore-plus/useq-schema/issues/187#issuecomment-2450480509

I'm not sure if this is the correct position for this fix, please check if this makes sense.