### PR TITLE
fix: fix for pydantic 2.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         include:
           - repo: pymmcore-plus/pymmcore-plus
-            qt: "pyside6"
+            qt: "pyqt6"
           - repo: pymmcore-plus/pymmcore-widgets
             qt: "pyqt6"
           # - repo: pymmcore-plus/napari-micromanager

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -19,6 +19,7 @@ from typing import (
 import numpy as np
 from annotated_types import Ge, Gt
 from pydantic import Field, field_validator, model_validator
+from typing_extensions import Annotated, Self, TypeAlias
 
 from useq._point_visiting import OrderMode, TraversalOrder
 from useq._position import (
@@ -29,8 +30,6 @@ from useq._position import (
 )
 
 if TYPE_CHECKING:
-    from typing_extensions import Annotated, Self, TypeAlias
-
     PointGenerator: TypeAlias = Callable[
         [np.random.RandomState, int, float, float], Iterable[tuple[float, float]]
     ]


### PR DESCRIPTION
Pydantic 2.10 broke importing of useq-schema.  You'll see this error:

```python
.venv/lib/python3.12/site-packages/pydantic/_internal/_generate_schema.py:817: in _resolve_forward_ref
    raise PydanticUndefinedAnnotation.from_name_error(e) from e
E   pydantic.errors.PydanticUndefinedAnnotation: name 'Annotated' is not defined
E
E   For further information visit https://errors.pydantic.dev/2.10/u/undefined-annotation
```

this PR fixes it, and should be released ASAP