### PR TITLE
feat: add MDAEvent.slm_image

### DIFF
--- a/src/useq/_mda_event.py
+++ b/src/useq/_mda_event.py
@@ -81,11 +81,9 @@ class SLMImage(UseqModel):
             v = {"data": v}
         return v
 
-    def __array__(
-        self, dtype: "npt.DTypeLike | None" = None, copy: "bool | None" = None
-    ) -> npt.NDArray:
+    def __array__(self, *args: Any, **kwargs: Any) -> npt.NDArray:
         """Cast the image data to a numpy array."""
-        return np.asarray(self.data, dtype=dtype, copy=copy)
+        return np.asarray(self.data, *args, **kwargs)
 
 
 class PropertyTuple(NamedTuple):

--- a/src/useq/_mda_event.py
+++ b/src/useq/_mda_event.py
@@ -69,10 +69,15 @@ class SLMImage(UseqModel):
         Optional name of the SLM device to use. If not provided, the "default" SLM
         device should be used. (It is left to the backend to determine what device that
         is). By default, `None`.
+    exposure: Optional[float]
+        Exposure time for the SLM specifically (if different from the detector), in
+        milliseconds. If not provided, the exposure on the owning MDAEvent should be
+        used. By default, `None`.
     """
 
     data: Any
     device: Optional[str] = None
+    exposure: Optional[float] = None
 
     @model_validator(mode="before")
     def _cast_data(cls, v: Any) -> Any:

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -462,3 +462,21 @@ def test_reset_event_timer() -> None:
     assert not events[1].reset_event_timer
     assert events[2].reset_event_timer
     assert not events[3].reset_event_timer
+
+
+def test_slm_image() -> None:
+    data = [[0, 0], [1, 1]]
+
+    # directly passing data
+    event = MDAEvent(slm_image=data)
+    assert event.slm_image is not None
+
+    # we can cast SLMIamge to a numpy array
+    assert isinstance(np.asarray(event.slm_image), np.ndarray)
+    np.testing.assert_array_equal(event.slm_image, np.array(data))
+
+    # variant that also specifies device label
+    event2 = MDAEvent(slm_image={"data": data, "device": "SLM"})
+    assert event2.slm_image is not None
+    np.testing.assert_array_equal(event2.slm_image, np.array(data))
+    assert event2.slm_image.device == "SLM"

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -22,6 +22,7 @@ from useq import (
     ZRangeAround,
     ZRelativePositions,
 )
+from useq._mda_event import SLMImage
 from useq._position import RelativePosition
 
 _T = List[Tuple[Any, Sequence[float]]]
@@ -469,7 +470,7 @@ def test_slm_image() -> None:
 
     # directly passing data
     event = MDAEvent(slm_image=data)
-    assert event.slm_image is not None
+    assert isinstance(event.slm_image, SLMImage)
 
     # we can cast SLMIamge to a numpy array
     assert isinstance(np.asarray(event.slm_image), np.ndarray)


### PR DESCRIPTION
closes #202 

- MDAEvent.slm_image is a new pydantic object SLMImage with two attributes (at the moment), data and device
- data is np.typing.ArrayLike (anything that can be case to a numpy array).  But for simplicity with pydantic, we type define it as `Any`.
- if device is None, it's up to the backend to pick the "current device"
- SLMImage is itself castable to a numpy array via `np.asarray(event.slm_image)`
- For now, I'm leaving all of the additional details that @hinderling mentioned in https://github.com/pymmcore-plus/useq-schema/issues/202#issuecomment-2490923194 (such as casting to different data types and dealing with device-specific on values) to backends like pymmcore[-plus]. 

```python
data = [[0, 0], [1, 1]]

# directly passing data
event = MDAEvent(slm_image=data)
assert event.slm_image is not None

# we can cast SLMIamge to a numpy array
assert isinstance(np.asarray(event.slm_image), np.ndarray)
np.testing.assert_array_equal(event.slm_image, np.array(data))

# variant that also specifies device label
event2 = MDAEvent(slm_image={"data": data, "device": "SLM"})
assert event2.slm_image is not None
np.testing.assert_array_equal(event2.slm_image, np.array(data))
assert event2.slm_image.device == "SLM"
```