### PR TITLE
feat: add CustomAction - a generic container for data needed to execute any custom (non-acquisition) event

### DIFF
--- a/src/useq/__init__.py
+++ b/src/useq/__init__.py
@@ -3,7 +3,7 @@
 import warnings
 from typing import Any
 
-from useq._actions import AcquireImage, Action, HardwareAutofocus
+from useq._actions import AcquireImage, Action, CustomAction, HardwareAutofocus
 from useq._channel import Channel
 from useq._grid import (
     GridFromEdges,
@@ -50,6 +50,7 @@ __all__ = [
     "AxesBasedAF",
     "Axis",
     "Channel",
+    "CustomAction",
     "EventChannel",
     "GridFromEdges",
     "GridRelative",

--- a/src/useq/_mda_event.py
+++ b/src/useq/_mda_event.py
@@ -174,7 +174,10 @@ class MDAEvent(UseqModel):
     action : Action
         The action to perform for this event.  By default, [`useq.AcquireImage`][].
         Example of another action is [`useq.HardwareAutofocus`][] which could be used
-        to perform a hardware autofocus.
+        to perform a hardware autofocus.  For backwards compatibility, an `action` of
+        `None` implies `AcquireImage`.  You may use `CustomAction` to indicate any
+        custom action, with the `data` attribute containing any data required to
+        perform the custom action.
     keep_shutter_open : bool
         If `True`, the illumination shutter should be left open after the event has
         been executed, otherwise it should be closed. By default, `False`."
@@ -199,7 +202,7 @@ class MDAEvent(UseqModel):
     sequence: Optional["MDASequence"] = Field(default=None, repr=False)
     properties: Optional[list[PropertyTuple]] = None
     metadata: dict[str, Any] = Field(default_factory=dict)
-    action: AnyAction = Field(default_factory=AcquireImage)
+    action: AnyAction = Field(default_factory=AcquireImage, discriminator="type")
     keep_shutter_open: bool = False
     reset_event_timer: bool = False
 


### PR DESCRIPTION
adds `useq.CustomAction`: an `Action` subclass that can be used to indicate any generic action.  This can represent anything, such as a fluidics event, or a photostimulation event, etc...  Data required to perform the action can be included in the `data` field, which is a dict.  user-provided `data` *must* be JSON-serializable, so as to avoid making the entire containing MDAEvent unserializable, and a ValidationError will be raised otherwise.  (Pydantic models may be use to capture complex things while retaining serialization)

this closes #213 - the fundamental need there was to allow for a way to indicate that `pymmcore-plus` should *never* try to perform hardware sequencing on a given event.  and this should accomplish this naturally (because pymmcore-plus already only tries to sequence acquisition events)