### PR TITLE
fix: Parse pydantic version with regex

### DIFF
--- a/src/useq/_base_model.py
+++ b/src/useq/_base_model.py
@@ -1,5 +1,5 @@
-from re import findall
 from pathlib import Path
+from re import findall
 from types import MappingProxyType
 from typing import (
     IO,
@@ -27,7 +27,7 @@ __all__ = ["FrozenModel", "UseqModel"]
 _T = TypeVar("_T", bound="FrozenModel")
 _Y = TypeVar("_Y", bound="UseqModel")
 
-PYDANTIC_VERSION = tuple(int(x) for x in findall(r'\d_', pydantic.__version__)[:3])
+PYDANTIC_VERSION = tuple(int(x) for x in findall(r"\d_", pydantic.__version__)[:3])
 GET_DEFAULT_KWARGS: dict = {}
 if PYDANTIC_VERSION >= (2, 10):
     GET_DEFAULT_KWARGS = {"validated_data": {}}


### PR DESCRIPTION
I was getting annoyed by some of the failures coming from here from the prerelease tests in [pymmcore-widgets](https://github.com/gselzer/pymmcore-widgets). This fix resolves the parsing errors with Pydantic prereleases.

```
Traceback (most recent call last):
  File "/Users/runner/hostedtoolcache/Python/3.11.9/x64/bin/mmcore", line 5, in <module>
    from pymmcore_plus._cli import main
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pymmcore_plus/__init__.py", line 13, in <module>
    from .core import (
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pymmcore_plus/core/__init__.py", line 25, in <module>
    from ._adapter import DeviceAdapter
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pymmcore_plus/core/_adapter.py", line 6, in <module>
    from pymmcore_plus.core._device import Device
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pymmcore_plus/core/_device.py", line 6, in <module>
    from ._property import DeviceProperty
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pymmcore_plus/core/_property.py", line 7, in <module>
    from .events._device_signal_view import _DevicePropValueSignal
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pymmcore_plus/core/events/__init__.py", line 6, in <module>
    from ._psygnal import CMMCoreSignaler
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pymmcore_plus/core/events/_psygnal.py", line 3, in <module>
    from pymmcore_plus.mda import MDAEngine
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pymmcore_plus/mda/__init__.py", line 1, in <module>
    from ._engine import MDAEngine
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/pymmcore_plus/mda/_engine.py", line 9, in <module>
    import useq
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/useq/__init__.py", line 6, in <module>
    from useq._actions import AcquireImage, Action, CustomAction, HardwareAutofocus
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/useq/_actions.py", line 7, in <module>
    from useq._base_model import FrozenModel
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/useq/_base_model.py", line 29, in <module>
    PYDANTIC_VERSION = tuple(int(x) for x in pydantic.__version__.split(".")[:3])
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/useq/_base_model.py", line 29, in <genexpr>
    PYDANTIC_VERSION = tuple(int(x) for x in pydantic.__version__.split(".")[:3])
                             ^^^^^^
ValueError: invalid literal for int() with base 10: '0b1'
```