### PR TITLE
feat: better plotting for grid plans

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.11.9
     hooks:
       - id: ruff
         args: [--fix, --unsafe-fixes]

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -16,6 +16,7 @@ from typing import (
 
 import numpy as np
 from annotated_types import Ge, Gt
+from matplotlib.axes import Axes
 from pydantic import Field, field_validator, model_validator
 from typing_extensions import Self, TypeAlias
 
@@ -28,6 +29,8 @@ from useq._position import (
 )
 
 if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
     PointGenerator: TypeAlias = Callable[
         [np.random.RandomState, int, float, float], Iterable[tuple[float, float]]
     ]
@@ -217,6 +220,22 @@ class GridFromEdges(_GridPlan[AbsolutePosition]):
 
     def _offset_y(self, dy: float) -> float:
         return max(self.top, self.bottom)
+
+    def plot(self, *, show: bool = True) -> Axes:
+        """Plot the positions in the plan."""
+        from useq._plot import plot_points
+
+        if self.fov_width is not None and self.fov_height is not None:
+            rect = (self.fov_width, self.fov_height)
+        else:
+            rect = None
+
+        return plot_points(
+            self,
+            rect_size=rect,
+            bounding_box=(self.left, self.top, self.right, self.bottom),
+            show=show,
+        )
 
 
 class GridRowsColumns(_GridPlan[RelativePosition]):

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -6,6 +6,7 @@ from pydantic import Field
 from useq._base_model import FrozenModel, MutableModel
 
 if TYPE_CHECKING:
+    from matplotlib.axes import Axes
     from typing_extensions import Self
 
     from useq import MDASequence
@@ -101,11 +102,16 @@ class _MultiPointPlan(MutableModel, Generic[PositionT]):
     def num_positions(self) -> int:
         raise NotImplementedError("This method must be implemented by subclasses.")
 
-    def plot(self) -> None:
+    def plot(self, *, show: bool = True) -> "Axes":
         """Plot the positions in the plan."""
         from useq._plot import plot_points
 
-        plot_points(self)
+        if self.fov_width is not None and self.fov_height is not None:
+            rect = (self.fov_width, self.fov_height)
+        else:
+            rect = None
+
+        return plot_points(self, rect_size=rect, show=show)
 
 
 class RelativePosition(PositionBase, _MultiPointPlan["RelativePosition"]):


### PR DESCRIPTION
This just adds field-of-view and outer-bounds plotting for grid plans, top help debugging #226 

```python
GridFromEdges(overlap=0, top=0, left=0, bottom=20, right=20, fov_height=10, fov_width=10).plot()
```
<img width="565" alt="Screenshot 2025-05-11 at 10 50 03 AM" src="https://github.com/user-attachments/assets/4e327aae-78f6-46eb-9557-267cfdbe6396" />


```python
GridFromEdges(overlap=10, top=0, left=0, bottom=20, right=30, fov_height=10, fov_width=20).plot()
```

<img width="553" alt="Screenshot 2025-05-11 at 10 50 58 AM" src="https://github.com/user-attachments/assets/e07d80c0-1546-49d0-889a-19bf22633ca3" />

