### PR TITLE
[WIP] feat: add polygon grid plan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "numpy >=1.26.0; python_version >= '3.12'",
     "numpy >=1.25.2",
     "typing-extensions >=4",
+    "shapely>=2.0.7",
 ]
 
 # extras

--- a/src/useq/__init__.py
+++ b/src/useq/__init__.py
@@ -7,6 +7,7 @@ from useq._actions import AcquireImage, Action, CustomAction, HardwareAutofocus
 from useq._channel import Channel
 from useq._grid import (
     GridFromEdges,
+    GridFromPolygon,
     GridRowsColumns,
     GridWidthHeight,
     MultiPointPlan,
@@ -57,6 +58,7 @@ __all__ = [
     "CustomAction",
     "EventChannel",
     "GridFromEdges",
+    "GridFromPolygon",
     "GridRelative",
     "GridRowsColumns",
     "GridWidthHeight",

--- a/tests/test_grid_and_points_plans.py
+++ b/tests/test_grid_and_points_plans.py
@@ -81,6 +81,23 @@ g_inputs = [
             useq.RelativePosition(x=-0.8, y=-0.4, name="0002"),
         ],
     ),
+    (
+        useq.GridFromPolygon(
+            vertices=[(0, 0), (4, 0), (2, 4)],
+            fov_width=2,
+            fov_height=2,
+            overlap=0,
+        ),
+        [
+            useq.Position(x=2.0, y=4.0, name="0000"),
+            useq.Position(x=4.0, y=2.0, name="0001"),
+            useq.Position(x=2.0, y=2.0, name="0002"),
+            useq.Position(x=0.0, y=2.0, name="0003"),
+            useq.Position(x=0.0, y=0.0, name="0004"),
+            useq.Position(x=2.0, y=0.0, name="0005"),
+            useq.Position(x=4.0, y=0.0, name="0006"),
+        ],
+    ),
 ]
 
 
@@ -281,4 +298,15 @@ def test_grid_from_edges_plot(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(mpl, "show", lambda: None)
     useq.GridFromEdges(
         overlap=10, top=0, left=0, bottom=20, right=30, fov_height=10, fov_width=20
+    ).plot()
+
+
+def test_grid_from_polygon_plot(monkeypatch: pytest.MonkeyPatch) -> None:
+    mpl = pytest.importorskip("matplotlib.pyplot")
+    monkeypatch.setattr(mpl, "show", lambda: None)
+    useq.GridFromPolygon(
+        vertices=[(0, 0), (10, 0), (10, 10), (0, 10)],
+        fov_width=3,
+        fov_height=3,
+        overlap=0,
     ).plot()


### PR DESCRIPTION
This PR adds a `GridFromPolygon` class to the `GripPlans`.

It is based on the `StageExplorer` widget of `pymmcore-widgets`: https://github.com/pymmcore-plus/pymmcore-widgets/blob/4f2b05fd1558aaa0eeb9ac3ba65ccf6235c866c8/src/pymmcore_widgets/control/_rois/_vispy.py#L15.

<img width="530" height="607" alt="Screenshot 2025-08-10 at 7 09 58 PM" src="https://github.com/user-attachments/assets/d89ce423-3860-44f8-9868-41a56058ae0c" />
