### PR TITLE
refactor: disallow self-intersecting GridFromPolygon

### DIFF
--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -458,12 +458,18 @@ class GridFromPolygon(_GridPlan[AbsolutePosition]):
     def is_relative(self) -> bool:
         return False
 
+    @field_validator("vertices", mode="after")
+    def validate_vertices(
+        cls, value: list[tuple[float, float]]
+    ) -> list[tuple[float, float]]:
+        if not Polygon(value).is_valid:
+            raise ValueError("Invalid or self-intersecting polygon.")
+        return value
+
     @property
     def poly(self) -> Polygon:
         """Return the processed polygon vertices as a shapely Polygon."""
         poly = Polygon(self.vertices)
-        if not poly.is_valid:
-            raise ValueError("Invalid or self-intersecting polygon.")
 
         # Apply offset if specified
         if self.offset is not None:

--- a/tests/test_grid_and_points_plans.py
+++ b/tests/test_grid_and_points_plans.py
@@ -354,3 +354,10 @@ def test_grid_from_polygon_with_convex_hull() -> None:
         overlap=0,
     )
     assert grid_with_hull.num_positions() == 9
+
+
+def test_invalid_poly() -> None:
+    """Test that self-intersecting polygons are invalid."""
+    vertices = [(0, 0), (2, 2), (0, 2), (2, 0)]
+    with pytest.raises(ValueError, match="Invalid or self-intersecting polygon"):
+        useq.GridFromPolygon(vertices=vertices, fov_width=1, fov_height=1)


### PR DESCRIPTION
until a valid use case comes along, we disallow self-intersecting polygons during grid plan creation