### PR TITLE
docs: update docstring ZAbsolutePositions

### DIFF
--- a/src/useq/_z.py
+++ b/src/useq/_z.py
@@ -165,8 +165,8 @@ class ZAbsolutePositions(ZPlan):
 
     Attributes
     ----------
-    relative : list[float]
-        List of relative z positions.
+    absolute : list[float]
+        List of absolute z positions.
     go_up : bool
         If `True` (the default), visits points in the order provided, otherwise in
         reverse.


### PR DESCRIPTION
I noticed that the docstring for `ZAbsolutePositions` referred to the attribute `relative`, which doesn't match the actual attribute `absolute`, so I updated the docstring accordingly. I tested building the docs, and everything builds correctly.

This is a very small change, so if it's easier for you to make this adjustment yourself, feel free to do so of course! This is my first public pull request, so it was a chance for me to get familiar with the pull request workflow.