### PR TITLE
feat: improve position validation for absolute/relative grid plans

### DIFF
--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -323,20 +323,20 @@ class MDASequence(UseqModel):
                 new_positions = list(self.stage_positions)
                 modified = False
                 for i, p in enumerate(new_positions):
-                    has_own_grid = (
-                        p.sequence is not None and p.sequence.grid_plan is not None
-                    )
                     if not self.grid_plan.is_relative:
                         # Absolute global grid: position x/y are ignored (the
                         # grid defines them). Warn (for now) and clear them.
+                        has_own_grid = (
+                            p.sequence is not None and p.sequence.grid_plan is not None
+                        )
                         if not has_own_grid and (p.x is not None or p.y is not None):
+                            grid_plan_type = type(self.grid_plan).__name__
                             warn(
                                 f"Position x={p.x!r}, y={p.y!r} is ignored when "
                                 f"using a global absolute grid plan "
-                                f"({type(self.grid_plan).__name__}). "
-                                "Set x=None, y=None on the position to silence "
-                                "this warning. In a future version this will "
-                                "raise an error.",
+                                f"({grid_plan_type}). Set x=None, y=None on the "
+                                "position to silence this warning. In a future version "
+                                "this will raise an error.",
                                 UserWarning,
                                 stacklevel=2,
                             )

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -340,23 +340,6 @@ class MDASequence(UseqModel):
                                 update={"x": None, "y": None}
                             )
                             modified = True
-                    else:
-                        # Relative global grid: positions must have x/y (the
-                        # grid offsets are added to the position).
-                        # Exception: positions with their own absolute sub-seq grid.
-                        has_own_absolute_grid = (
-                            p.sequence is not None
-                            and p.sequence.grid_plan is not None
-                            and not p.sequence.grid_plan.is_relative
-                        )
-                        if not has_own_absolute_grid and (p.x is None or p.y is None):
-                            raise ValueError(
-                                f"Position x={p.x!r}, y={p.y!r} has no defined "
-                                "x/y coordinates. When using a relative grid "
-                                "plan, all stage positions must provide x and y "
-                                "because the grid offsets are applied relative "
-                                "to the position."
-                            )
                 if modified:
                     object.__setattr__(self, "stage_positions", tuple(new_positions))
         return self

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -313,7 +313,6 @@ class MDASequence(UseqModel):
                         "keep_shutter_open_across cannot currently be set on a "
                         "Position sequence"
                     )
-
             # it's invalid to have stage positions with x/y coordinates
             # when using a global absolute grid plan
             if self.grid_plan is not None and not self.grid_plan.is_relative:

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -19,11 +19,7 @@ from useq._grid import MultiPointPlan  # noqa: TC001
 from useq._hardware_autofocus import AnyAutofocusPlan, AxesBasedAF
 from useq._iter_sequence import iter_sequence
 from useq._plate import WellPlatePlan
-from useq._position import (
-    Position,
-    PositionBase,
-    RelativePosition,  # only for isinstance rejection
-)
+from useq._position import Position, PositionBase, RelativePosition
 from useq._time import AnyTimePlan  # noqa: TC001
 from useq._utils import TimeEstimate, estimate_sequence_duration
 from useq._z import AnyZPlan  # noqa: TC001

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -258,8 +258,8 @@ class MDASequence(UseqModel):
             if isinstance(v, RelativePosition):
                 raise ValueError(
                     "RelativePosition cannot be used in stage_positions. "
-                    "Use Position (AbsolutePosition) instead. For z-only "
-                    "positions, use Position(x=None, y=None, z=<value>)."
+                    "Use AbsolutePosition (Position)) instead. For z-only "
+                    "positions, use Position(z=<value>)."
                 )
             if isinstance(v, Position):
                 positions.append(v)

--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -377,6 +377,31 @@ class MDASequence(UseqModel):
                         "keep_shutter_open_across cannot currently be set on a "
                         "Position sequence"
                     )
+
+            # warn and clear x/y on positions when using a global absolute grid
+            if self.grid_plan is not None and not self.grid_plan.is_relative:
+                new_positions = list(self.stage_positions)
+                for i, p in enumerate(new_positions):
+                    # skip positions with their own sub-sequence grid;
+                    # x/y serves as the origin for that grid
+                    if p.sequence is not None and p.sequence.grid_plan:
+                        continue
+                    if p.x is not None or p.y is not None:
+                        import warnings
+
+                        warnings.warn(
+                            f"Position x={p.x!r}, y={p.y!r} is ignored when "
+                            f"using a global absolute grid plan "
+                            f"({type(self.grid_plan).__name__}). "
+                            "Set x=None, y=None on the position to silence "
+                            "this warning. In a future version this will raise "
+                            "an error.",
+                            UserWarning,
+                            stacklevel=2,
+                        )
+                        new_positions[i] = p.model_copy(update={"x": None, "y": None})
+                object.__setattr__(self, "stage_positions", tuple(new_positions))
+
         return self
 
     def __eq__(self, other: Any) -> bool:

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -92,36 +92,6 @@ class PositionBase(MutableModel):
         return value
 
 
-PositionT = TypeVar("PositionT", bound=PositionBase)
-
-
-class _MultiPointPlan(MutableModel, Generic[PositionT]):
-    """Any plan that yields multiple positions."""
-
-    fov_width: float | None = None
-    fov_height: float | None = None
-
-    @property
-    def is_relative(self) -> bool:
-        return True
-
-    def __iter__(self) -> Iterator[PositionT]:  # type: ignore [override]
-        raise NotImplementedError("This method must be implemented by subclasses.")
-
-    def num_positions(self) -> int:
-        raise NotImplementedError("This method must be implemented by subclasses.")
-
-    def plot(self, *, show: bool = True) -> "Axes":
-        """Plot the positions in the plan."""
-        from useq._plot import plot_points
-
-        rect = None
-        if self.fov_width is not None and self.fov_height is not None:
-            rect = (self.fov_width, self.fov_height)
-
-        return plot_points(self, rect_size=rect, show=show)
-
-
 class AbsolutePosition(PositionBase, FrozenModel):
     """An absolute position in 3D space."""
 
@@ -164,6 +134,34 @@ class AbsolutePosition(PositionBase, FrozenModel):
 
 
 Position = AbsolutePosition
+PositionT = TypeVar("PositionT", bound=PositionBase)
+
+
+class _MultiPointPlan(MutableModel, Generic[PositionT]):
+    """Any plan that yields multiple positions."""
+
+    fov_width: float | None = None
+    fov_height: float | None = None
+
+    @property
+    def is_relative(self) -> bool:
+        return True
+
+    def __iter__(self) -> Iterator[PositionT]:  # type: ignore [override]
+        raise NotImplementedError("This method must be implemented by subclasses.")
+
+    def num_positions(self) -> int:
+        raise NotImplementedError("This method must be implemented by subclasses.")
+
+    def plot(self, *, show: bool = True) -> "Axes":
+        """Plot the positions in the plan."""
+        from useq._plot import plot_points
+
+        rect = None
+        if self.fov_width is not None and self.fov_height is not None:
+            rect = (self.fov_width, self.fov_height)
+
+        return plot_points(self, rect_size=rect, show=show)
 
 
 class RelativePosition(PositionBase, _MultiPointPlan["RelativePosition"]):

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -119,17 +119,7 @@ class AbsolutePosition(PositionBase, FrozenModel):
                 )
                 object.__setattr__(self, "x", None)
                 object.__setattr__(self, "y", None)
-        else:
-            # x/y are required with a relative sub-grid (offsets are applied
-            # relative to the position).
-            if self.x is None or self.y is None:
-                raise ValueError(
-                    f"Position x={self.x!r}, y={self.y!r} has no defined x/y "
-                    f"coordinates. When a position sequence uses a relative "
-                    f"grid plan ({type(grid).__name__}), the position must "
-                    "provide x and y because the grid offsets are applied "
-                    "relative to the position."
-                )
+
         return self
 
 

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -86,7 +86,7 @@ class PositionBase(MutableModel):
     @model_validator(mode="before")
     @classmethod
     def _cast(cls, value: Any) -> Any:
-        if isinstance(value, np.ndarray | tuple):
+        if isinstance(value, (np.ndarray, tuple)):
             x = y = z = None
             if len(value) > 0:
                 x = value[0]
@@ -115,11 +115,10 @@ class AbsolutePosition(PositionBase, FrozenModel):
             # them). Warn and clear.
             if self.x is not None or self.y is not None:
                 warnings.warn(
-                    f"Position x={self.x!r}, y={self.y!r} is ignored when a "
-                    f"position sequence uses an absolute grid plan "
-                    f"({type(grid).__name__}). "
-                    "Set x=None, y=None on the position to silence this "
-                    "warning. In a future version this will raise an error.",
+                    f"Position x={self.x!r}, y={self.y!r} is ignored when a position "
+                    f"sequence uses an absolute grid plan ({type(grid).__name__}). "
+                    "Set x=None, y=None on the position to silence this warning. "
+                    "In a future version this will raise an error.",
                     UserWarning,
                     stacklevel=2,
                 )
@@ -129,7 +128,7 @@ class AbsolutePosition(PositionBase, FrozenModel):
         return self
 
 
-Position = AbsolutePosition
+Position = AbsolutePosition  # for backwards compatibility
 PositionT = TypeVar("PositionT", bound=PositionBase)
 
 

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -53,12 +53,18 @@ class PositionBase(MutableModel):
         """Add two positions together to create a new position."""
         if not isinstance(other, RelativePosition):  # pragma: no cover
             return NotImplemented
-        if (x := self.x) is not None and other.x is not None:
-            x += other.x
-        if (y := self.y) is not None and other.y is not None:
-            y += other.y
-        if (z := self.z) is not None and other.z is not None:
-            z += other.z
+        if self.x is not None and other.x is not None:
+            x = self.x + other.x
+        else:
+            x = self.x if other.x is None else other.x
+        if self.y is not None and other.y is not None:
+            y = self.y + other.y
+        else:
+            y = self.y if other.y is None else other.y
+        if self.z is not None and other.z is not None:
+            z = self.z + other.z
+        else:
+            z = self.z if other.z is None else other.z
         if (name := self.name) and other.name:
             name = f"{name}_{other.name}"
         kwargs = {**self.model_dump(), "x": x, "y": y, "z": z, "name": name}

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Generic, Optional, SupportsIndex, TypeVar
 

--- a/tests/fixtures/cases.py
+++ b/tests/fixtures/cases.py
@@ -1128,8 +1128,6 @@ KEEP_SHUTTER_CASES: list[MDATestCase] = [
             channels=["DAPI", "FITC"],
             stage_positions=[
                 Position(
-                    x=0,
-                    y=0,
                     sequence=MDASequence(grid_plan=GridRowsColumns(rows=2, columns=2)),
                 )
             ],

--- a/tests/fixtures/cases.py
+++ b/tests/fixtures/cases.py
@@ -301,8 +301,12 @@ GRID_SUBSEQ_CASES: list[MDATestCase] = [
         name="multi_g_in_position_sub_sequence",
         seq=MDASequence(
             stage_positions=[
-                {"sequence": {"grid_plan": {"rows": 1, "columns": 2}}},
-                {"sequence": {"grid_plan": GridRowsColumns(rows=2, columns=2)}},
+                {"x": 0, "y": 0, "sequence": {"grid_plan": {"rows": 1, "columns": 2}}},
+                {
+                    "x": 0,
+                    "y": 0,
+                    "sequence": {"grid_plan": GridRowsColumns(rows=2, columns=2)},
+                },
                 {
                     "sequence": {
                         "grid_plan": GridFromEdges(top=1, bottom=-1, left=0, right=0)
@@ -884,7 +888,7 @@ AF_CASES: list[MDATestCase] = [
     MDATestCase(
         name="af_axes_g_basic",
         seq=MDASequence(
-            stage_positions=[Position(z=30)],
+            stage_positions=[Position(x=0, y=0, z=30)],
             channels=["DAPI", "FITC"],
             grid_plan=GridRowsColumns(rows=2, columns=1),
             autofocus_plan=AxesBasedAF(autofocus_device_name="Z", axes=("g",)),
@@ -1124,7 +1128,9 @@ KEEP_SHUTTER_CASES: list[MDATestCase] = [
             channels=["DAPI", "FITC"],
             stage_positions=[
                 Position(
-                    sequence=MDASequence(grid_plan=GridRowsColumns(rows=2, columns=2))
+                    x=0,
+                    y=0,
+                    sequence=MDASequence(grid_plan=GridRowsColumns(rows=2, columns=2)),
                 )
             ],
             keep_shutter_open_across="g",

--- a/tests/fixtures/cases.py
+++ b/tests/fixtures/cases.py
@@ -172,8 +172,8 @@ GRID_SUBSEQ_CASES: list[MDATestCase] = [
             stage_positions=[
                 Position(x=0, y=0),
                 Position(
-                    x=10,
-                    y=10,
+                    x=None,
+                    y=None,
                     sequence={
                         "grid_plan": GridFromEdges(top=1, bottom=-1, left=0, right=0)
                     },

--- a/tests/fixtures/cases.py
+++ b/tests/fixtures/cases.py
@@ -606,7 +606,7 @@ GRID_SUBSEQ_CASES: list[MDATestCase] = [
         seq=MDASequence(
             axis_order="tpgcz",
             stage_positions=[
-                Position(x=0, y=0),
+                Position(z=2),
                 Position(
                     name="name",
                     x=10,

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ValidationError
 from useq import (
     MDAEvent,
     MDASequence,
+    Position,
     TIntervalDuration,
     ZAboveBelow,
     ZRangeAround,
@@ -89,7 +90,7 @@ def test_axis_order_errors() -> None:
     MDASequence(
         stage_positions=[
             {"z": 0},
-            {"sequence": {"grid_plan": {"rows": 2, "columns": 2}}},
+            {"x": 0, "y": 0, "sequence": {"grid_plan": {"rows": 2, "columns": 2}}},
             {
                 "sequence": {
                     "grid_plan": {"top": 1, "bottom": -1, "left": 0, "right": 0}
@@ -116,8 +117,10 @@ def test_axis_order_errors() -> None:
             stage_positions=[{"x": 10, "y": 20}],
             grid_plan={"top": 1, "bottom": -1, "left": 0, "right": 0},
         )
-    assert seq.stage_positions[0].x is None
-    assert seq.stage_positions[0].y is None
+    pos = seq.stage_positions[0]
+    assert isinstance(pos, Position)
+    assert pos.x is None
+    assert pos.y is None
     # --- GridFromPolygon ---
     with pytest.warns(
         UserWarning, match="is ignored when using a global absolute grid plan"
@@ -130,8 +133,10 @@ def test_axis_order_errors() -> None:
                 "fov_height": 2,
             },
         )
-    assert seq.stage_positions[0].x is None
-    assert seq.stage_positions[0].y is None
+    pos = seq.stage_positions[0]
+    assert isinstance(pos, Position)
+    assert pos.x is None
+    assert pos.y is None
 
     # no warning when x/y are None with absolute grids
     MDASequence(

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel, ValidationError
 from useq import (
     MDAEvent,
     MDASequence,
-    Position,
     TIntervalDuration,
     ZAboveBelow,
     ZRangeAround,
@@ -117,10 +116,8 @@ def test_axis_order_errors() -> None:
             stage_positions=[{"x": 10, "y": 20}],
             grid_plan={"top": 1, "bottom": -1, "left": 0, "right": 0},
         )
-    pos = seq.stage_positions[0]
-    assert isinstance(pos, Position)
-    assert pos.x is None
-    assert pos.y is None
+    assert seq.stage_positions[0].x is None
+    assert seq.stage_positions[0].y is None
     # --- GridFromPolygon ---
     with pytest.warns(
         UserWarning, match="is ignored when using a global absolute grid plan"
@@ -133,10 +130,8 @@ def test_axis_order_errors() -> None:
                 "fov_height": 2,
             },
         )
-    pos = seq.stage_positions[0]
-    assert isinstance(pos, Position)
-    assert pos.x is None
-    assert pos.y is None
+    assert seq.stage_positions[0].x is None
+    assert seq.stage_positions[0].y is None
 
     # no warning when x/y are None with absolute grids
     MDASequence(

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -89,7 +89,7 @@ def test_axis_order_errors() -> None:
     MDASequence(
         stage_positions=[
             {"z": 0},
-            {"x": 0, "y": 0, "sequence": {"grid_plan": {"rows": 2, "columns": 2}}},
+            {"sequence": {"grid_plan": {"rows": 2, "columns": 2}}},
             {
                 "sequence": {
                     "grid_plan": {"top": 1, "bottom": -1, "left": 0, "right": 0}

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -73,7 +73,7 @@ def test_axis_order_errors() -> None:
 
     with pytest.warns(UserWarning, match="Global grid plan will override"):
         MDASequence(
-            stage_positions=[(0, 0, 0), (10, 10, 10)],
+            stage_positions=[{"z": 0}, {"z": 10}],
             grid_plan={"top": 1, "bottom": -1, "left": 0, "right": 0},
         )
 
@@ -87,7 +87,7 @@ def test_axis_order_errors() -> None:
     MDASequence(
         stage_positions=[
             {"z": 0},
-            {"x": 0, "y": 0, "sequence": {"grid_plan": {"rows": 2, "columns": 2}}},
+            {"sequence": {"grid_plan": {"rows": 2, "columns": 2}}},
             {
                 "sequence": {
                     "grid_plan": {"top": 1, "bottom": -1, "left": 0, "right": 0}

--- a/tests/test_stage_positions.py
+++ b/tests/test_stage_positions.py
@@ -43,7 +43,7 @@ _ABSOLUTE_GRID_PLANS = [
     ),
 ]
 
-_RELATIVE_SUB_GRID_PLANS = [
+_RELATIVE_GRID_PLANS = [
     pytest.param({"rows": 2, "columns": 2}, id="GridRowsColumns"),
     pytest.param(
         useq.RandomPoints(num_points=3, max_width=100, max_height=100),
@@ -63,115 +63,95 @@ def test_position_warns_on_absolute_sub_sequence_grid(
     assert pos.y is None
 
 
-@pytest.mark.parametrize("sub_plan", _RELATIVE_SUB_GRID_PLANS)
-def test_position_no_warn_on_relative_sub_sequence_grid(sub_plan: Any) -> None:
+@pytest.mark.parametrize("grid_plan", _RELATIVE_GRID_PLANS)
+def test_position_no_warn_on_relative_sub_sequence_grid(grid_plan: Any) -> None:
     """Position keeps x/y when sub-sequence uses a relative grid."""
-    pos = useq.Position(x=1, y=2, sequence={"grid_plan": sub_plan})
+    pos = useq.Position(x=1, y=2, sequence={"grid_plan": grid_plan})
     assert pos.x == 1
     assert pos.y == 2
 
 
-@pytest.mark.parametrize("sub_plan", _RELATIVE_SUB_GRID_PLANS)
-def test_position_none_xy_allowed_with_relative_sub_sequence_grid(
-    sub_plan: Any,
+# --- __add__ / __radd__ -----------------------------------------------------------
+
+_ADD_CASES = [
+    pytest.param(
+        useq.Position(x=1, y=2, z=3),
+        useq.RelativePosition(x=5, y=10, z=1),
+        (6, 12, 4),
+        id="both_have_values",
+    ),
+    pytest.param(
+        useq.Position(x=None, y=None, z=3),
+        useq.RelativePosition(x=5, y=10, z=0),
+        (5, 10, 3),
+        id="none_falls_back_to_other",
+    ),
+    pytest.param(
+        useq.Position(x=1, y=2, z=3),
+        useq.RelativePosition(x=0, y=0, z=0),
+        (1, 2, 3),
+        id="add_zero",
+    ),
+]
+
+
+@pytest.mark.parametrize("pos, rel, expected", _ADD_CASES)
+def test_position_add(
+    pos: useq.Position, rel: useq.RelativePosition, expected: tuple
 ) -> None:
-    """Position with x=None or y=None is allowed when sub-sequence uses a relative grid."""
-    pos = useq.Position(x=None, y=None, z=3, sequence={"grid_plan": sub_plan})
-    assert pos.x is None
-    assert pos.y is None
-    assert pos.z == 3
-
-
-def test_add_with_none_coordinates() -> None:
-    """__add__ preserves None when self coordinate is None (no fallback to other)."""
-    pos = useq.Position(x=None, y=None, z=3)
-    rel = useq.RelativePosition(x=5, y=10, z=0)
     result = pos + rel
-    assert result.x is None
-    assert result.y is None
-    assert result.z == 3
+    assert (result.x, result.y, result.z) == expected
 
 
-def test_add_both_have_values() -> None:
-    """__add__ sums values when both sides have them."""
-    pos = useq.Position(x=1, y=2, z=3)
-    rel = useq.RelativePosition(x=5, y=10, z=1)
-    result = pos + rel
-    assert result.x == 6
-    assert result.y == 12
-    assert result.z == 4
-
-
-def test_radd() -> None:
+def test_position_radd() -> None:
     """__radd__ supports reversed addition (RelativePosition + AbsolutePosition)."""
     pos = useq.Position(x=1, y=2, z=3)
     rel = useq.RelativePosition(x=5, y=10, z=0)
     result = rel + pos
-    assert result.x == 6
-    assert result.y == 12
-    assert result.z == 3
+    assert (result.x, result.y, result.z) == (6, 12, 3)
+
+
+# --- RelativePosition rejected in stage_positions --------------------------------
+
+
+def test_relative_position_rejected_in_stage_positions() -> None:
+    """RelativePosition is always rejected in stage_positions."""
+    with pytest.raises(Exception, match="RelativePosition cannot be used"):
+        useq.MDASequence(stage_positions=[useq.RelativePosition(x=1, y=2, z=3)])
+
+
+# --- Global grid + position interactions -----------------------------------------
 
 
 @pytest.mark.parametrize("grid_plan", _ABSOLUTE_GRID_PLANS)
 def test_z_only_position_with_absolute_grid(grid_plan: dict) -> None:
-    """Position(x=None, y=None, z=3) stays AbsolutePosition with absolute grid."""
+    """Position(x=None, y=None, z=3) with absolute grid: no warning, z preserved."""
     seq = useq.MDASequence(
         stage_positions=[(None, None, 3)],
         grid_plan=grid_plan,
     )
-    assert len(seq.stage_positions) == 1
     pos = seq.stage_positions[0]
-    assert isinstance(pos, useq.Position)
     assert pos.x is None
     assert pos.y is None
     assert pos.z == 3
 
 
 @pytest.mark.parametrize("grid_plan", _ABSOLUTE_GRID_PLANS)
-def test_warns_and_clears_xy_with_absolute_grid(grid_plan: dict) -> None:
-    """Warns when positions have x/y with absolute grid, clears x/y."""
-    with pytest.warns(UserWarning, match="is ignored when using"):
+def test_absolute_grid_warns_only_positions_with_xy(grid_plan: dict) -> None:
+    """With a global absolute grid, only positions that have x/y produce a warning."""
+    with pytest.warns(UserWarning) as record:
         seq = useq.MDASequence(
-            stage_positions=[(1, 2, 3)],
+            stage_positions=[(1, 2, 3), (None, None, 5)],
             grid_plan=grid_plan,
         )
-    pos = seq.stage_positions[0]
-    assert isinstance(pos, useq.Position)
-    assert pos.x is None
-    assert pos.y is None
-    assert pos.z == 3
-
-
-@pytest.mark.parametrize("grid_plan", _ABSOLUTE_GRID_PLANS)
-def test_sub_sequence_absolute_grid_stays_position(grid_plan: dict) -> None:
-    """Position with sub-sequence absolute grid stays AbsolutePosition."""
-    seq = useq.MDASequence(
-        stage_positions=[
-            useq.Position(x=None, y=None, z=3.0, sequence={"grid_plan": grid_plan})
-        ]
-    )
-    pos = seq.stage_positions[0]
-    assert isinstance(pos, useq.Position)
-    assert pos.x is None
-    assert pos.y is None
-    assert pos.z == 3.0
-    assert pos.sequence is not None
-
-
-@pytest.mark.parametrize("grid_plan", _ABSOLUTE_GRID_PLANS)
-def test_sub_sequence_absolute_grid_warns_and_clears_xy(grid_plan: dict) -> None:
-    """Position with x/y + sub-sequence absolute grid warns then clears x/y."""
-    with pytest.warns(UserWarning, match="is ignored when a position sequence uses"):
-        seq = useq.MDASequence(
-            stage_positions=[
-                useq.Position(x=1, y=2, z=3.0, sequence={"grid_plan": grid_plan})
-            ]
-        )
-    pos = seq.stage_positions[0]
-    assert isinstance(pos, useq.Position)
-    assert pos.x is None
-    assert pos.y is None
-    assert pos.z == 3.0
+    xy_warns = [w for w in record if "is ignored when using" in str(w.message)]
+    assert len(xy_warns) == 1
+    assert seq.stage_positions[0].x is None
+    assert seq.stage_positions[0].y is None
+    assert seq.stage_positions[0].z == 3
+    assert seq.stage_positions[1].x is None
+    assert seq.stage_positions[1].y is None
+    assert seq.stage_positions[1].z == 5
 
 
 def test_warns_global_abs_grid_does_not_mutate_original_position() -> None:
@@ -184,69 +164,16 @@ def test_warns_global_abs_grid_does_not_mutate_original_position() -> None:
         )
     assert pos.x == 1  # original must be untouched
     assert pos.y == 2
-    assert seq.stage_positions[0].x is None  # sequence view is updated
+    assert seq.stage_positions[0].x is None  # sequence copy is updated
     assert seq.stage_positions[0].y is None
 
 
-def test_relative_position_rejected_in_stage_positions() -> None:
-    """RelativePosition is always rejected in stage_positions."""
-    with pytest.raises(Exception, match="RelativePosition cannot be used"):
-        useq.MDASequence(stage_positions=[useq.RelativePosition(x=1, y=2, z=3)])
-
-    # Also rejected even with an absolute grid
-    with pytest.raises(Exception, match="RelativePosition cannot be used"):
-        useq.MDASequence(
-            stage_positions=[useq.RelativePosition(z=3)],
-            grid_plan={"top": 1, "bottom": -1, "left": 0, "right": 0},
-        )
-
-
-_RELATIVE_GRID_PLANS = [
-    pytest.param({"rows": 2, "columns": 2}, id="GridRowsColumns"),
-    pytest.param(
-        useq.RandomPoints(num_points=3, max_width=100, max_height=100),
-        id="RandomPoints",
-    ),
-]
-
-
-@pytest.mark.parametrize("grid_plan", _RELATIVE_GRID_PLANS)
-def test_position_none_xy_allowed_with_relative_grid(grid_plan: dict) -> None:
-    """Position with x=None or y=None is allowed when global grid is relative."""
-    seq = useq.MDASequence(
-        stage_positions=[(None, None, 3)],
-        grid_plan=grid_plan,
-    )
-    pos = seq.stage_positions[0]
-    assert pos.x is None
-    assert pos.y is None
-    assert pos.z == 3
-
-
-@pytest.mark.parametrize("grid_plan", _RELATIVE_GRID_PLANS)
-def test_position_none_xy_with_relative_grid_exempt_if_own_absolute_sub_grid(
-    grid_plan: dict,
-) -> None:
-    """Position with x=None/y=None is exempt if it has its own absolute sub-seq grid."""
-    seq = useq.MDASequence(
-        stage_positions=[
-            useq.Position(x=1, y=2, z=3),
-            useq.Position(
-                name="sub",
-                sequence={"grid_plan": {"top": 1, "bottom": -1, "left": 0, "right": 0}},
-            ),
-        ],
-        grid_plan=grid_plan,
-    )
-    assert len(seq.stage_positions) == 2
-
-
 @pytest.mark.parametrize("global_plan", _ABSOLUTE_GRID_PLANS)
-@pytest.mark.parametrize("sub_plan", _RELATIVE_SUB_GRID_PLANS)
-def test_position_with_xy_and_relative_sub_grid_exempt_from_absolute_global_grid(
+@pytest.mark.parametrize("sub_plan", _RELATIVE_GRID_PLANS)
+def test_position_with_own_grid_exempt_from_global_absolute_grid(
     global_plan: dict, sub_plan: Any
 ) -> None:
-    """Position with x/y + relative sub-grid is exempt from global abs grid x/y clearing."""
+    """Position with its own sub-grid is exempt from global abs grid x/y clearing."""
     seq = useq.MDASequence(
         stage_positions=[
             useq.Position(x=1, y=2, z=3, sequence={"grid_plan": sub_plan})
@@ -256,41 +183,6 @@ def test_position_with_xy_and_relative_sub_grid_exempt_from_absolute_global_grid
     pos = seq.stage_positions[0]
     assert pos.x == 1
     assert pos.y == 2
-
-
-@pytest.mark.parametrize("grid_plan", _ABSOLUTE_GRID_PLANS)
-def test_absolute_grid_warns_only_positions_with_xy(grid_plan: dict) -> None:
-    """With a global absolute grid, only positions that have x/y produce a warning."""
-    with pytest.warns(UserWarning) as record:
-        seq = useq.MDASequence(
-            stage_positions=[(1, 2, 3), (None, None, 5)],
-            grid_plan=grid_plan,
-        )
-    # exactly one "is ignored" warning: only the first position had x/y
-    xy_warns = [w for w in record if "is ignored when using" in str(w.message)]
-    assert len(xy_warns) == 1
-    assert seq.stage_positions[0].x is None
-    assert seq.stage_positions[0].y is None
-    assert seq.stage_positions[0].z == 3
-    assert seq.stage_positions[1].x is None  # was already None, no warning
-    assert seq.stage_positions[1].y is None
-    assert seq.stage_positions[1].z == 5
-
-
-@pytest.mark.parametrize("grid_plan", _RELATIVE_GRID_PLANS)
-def test_relative_grid_allows_missing_xy(grid_plan: dict) -> None:
-    """With a relative global grid, missing x/y are allowed (stay None)."""
-    seq = useq.MDASequence(
-        stage_positions=[
-            useq.Position(x=1, y=2, z=0),
-            useq.Position(x=None, y=None, z=3),
-        ],
-        grid_plan=grid_plan,
-    )
-    assert seq.stage_positions[0].x == 1
-    assert seq.stage_positions[0].y == 2
-    assert seq.stage_positions[1].x is None
-    assert seq.stage_positions[1].y is None
 
 
 @pytest.mark.parametrize("grid_plan", _ABSOLUTE_GRID_PLANS)

--- a/tests/test_stage_positions.py
+++ b/tests/test_stage_positions.py
@@ -72,12 +72,14 @@ def test_position_no_warn_on_relative_sub_sequence_grid(sub_plan: Any) -> None:
 
 
 @pytest.mark.parametrize("sub_plan", _RELATIVE_SUB_GRID_PLANS)
-def test_position_none_xy_rejected_with_relative_sub_sequence_grid(
+def test_position_none_xy_allowed_with_relative_sub_sequence_grid(
     sub_plan: Any,
 ) -> None:
-    """Position with x=None or y=None raises when sub-sequence uses a relative grid."""
-    with pytest.raises(Exception, match="has no defined x/y coordinates"):
-        useq.Position(x=None, y=None, z=3, sequence={"grid_plan": sub_plan})
+    """Position with x=None or y=None is allowed when sub-sequence uses a relative grid."""
+    pos = useq.Position(x=None, y=None, z=3, sequence={"grid_plan": sub_plan})
+    assert pos.x is None
+    assert pos.y is None
+    assert pos.z == 3
 
 
 def test_add_with_none_coordinates() -> None:
@@ -209,13 +211,16 @@ _RELATIVE_GRID_PLANS = [
 
 
 @pytest.mark.parametrize("grid_plan", _RELATIVE_GRID_PLANS)
-def test_position_none_xy_rejected_with_relative_grid(grid_plan: dict) -> None:
-    """Position with x=None or y=None raises when the global grid plan is relative."""
-    with pytest.raises(Exception, match="has no defined x/y coordinates"):
-        useq.MDASequence(
-            stage_positions=[(None, None, 3)],
-            grid_plan=grid_plan,
-        )
+def test_position_none_xy_allowed_with_relative_grid(grid_plan: dict) -> None:
+    """Position with x=None or y=None is allowed when global grid is relative."""
+    seq = useq.MDASequence(
+        stage_positions=[(None, None, 3)],
+        grid_plan=grid_plan,
+    )
+    pos = seq.stage_positions[0]
+    assert pos.x is None
+    assert pos.y is None
+    assert pos.z == 3
 
 
 @pytest.mark.parametrize("grid_plan", _RELATIVE_GRID_PLANS)
@@ -273,16 +278,19 @@ def test_absolute_grid_warns_only_positions_with_xy(grid_plan: dict) -> None:
 
 
 @pytest.mark.parametrize("grid_plan", _RELATIVE_GRID_PLANS)
-def test_relative_grid_raises_if_any_position_missing_xy(grid_plan: dict) -> None:
-    """With a relative global grid, a ValueError is raised if any position lacks x/y."""
-    with pytest.raises(ValueError, match="has no defined x/y coordinates"):
-        useq.MDASequence(
-            stage_positions=[
-                useq.Position(x=1, y=2, z=0),
-                useq.Position(x=None, y=None, z=3),
-            ],
-            grid_plan=grid_plan,
-        )
+def test_relative_grid_allows_missing_xy(grid_plan: dict) -> None:
+    """With a relative global grid, missing x/y are allowed (stay None)."""
+    seq = useq.MDASequence(
+        stage_positions=[
+            useq.Position(x=1, y=2, z=0),
+            useq.Position(x=None, y=None, z=3),
+        ],
+        grid_plan=grid_plan,
+    )
+    assert seq.stage_positions[0].x == 1
+    assert seq.stage_positions[0].y == 2
+    assert seq.stage_positions[1].x is None
+    assert seq.stage_positions[1].y is None
 
 
 @pytest.mark.parametrize("grid_plan", _ABSOLUTE_GRID_PLANS)

--- a/tests/test_stage_positions.py
+++ b/tests/test_stage_positions.py
@@ -86,12 +86,6 @@ _ADD_CASES = [
         (5, 10, 3),
         id="none_falls_back_to_other",
     ),
-    pytest.param(
-        useq.Position(x=1, y=2, z=3),
-        useq.RelativePosition(x=0, y=0, z=0),
-        (1, 2, 3),
-        id="add_zero",
-    ),
 ]
 
 
@@ -123,37 +117,6 @@ def test_relative_position_rejected_in_stage_positions() -> None:
 # --- Global grid + position interactions -----------------------------------------
 
 
-@pytest.mark.parametrize("grid_plan", _ABSOLUTE_GRID_PLANS)
-def test_z_only_position_with_absolute_grid(grid_plan: dict) -> None:
-    """Position(x=None, y=None, z=3) with absolute grid: no warning, z preserved."""
-    seq = useq.MDASequence(
-        stage_positions=[(None, None, 3)],
-        grid_plan=grid_plan,
-    )
-    pos = seq.stage_positions[0]
-    assert pos.x is None
-    assert pos.y is None
-    assert pos.z == 3
-
-
-@pytest.mark.parametrize("grid_plan", _ABSOLUTE_GRID_PLANS)
-def test_absolute_grid_warns_only_positions_with_xy(grid_plan: dict) -> None:
-    """With a global absolute grid, only positions that have x/y produce a warning."""
-    with pytest.warns(UserWarning) as record:
-        seq = useq.MDASequence(
-            stage_positions=[(1, 2, 3), (None, None, 5)],
-            grid_plan=grid_plan,
-        )
-    xy_warns = [w for w in record if "is ignored when using" in str(w.message)]
-    assert len(xy_warns) == 1
-    assert seq.stage_positions[0].x is None
-    assert seq.stage_positions[0].y is None
-    assert seq.stage_positions[0].z == 3
-    assert seq.stage_positions[1].x is None
-    assert seq.stage_positions[1].y is None
-    assert seq.stage_positions[1].z == 5
-
-
 def test_warns_global_abs_grid_does_not_mutate_original_position() -> None:
     """Clearing x/y for a global absolute grid must not mutate the original Position."""
     pos = useq.Position(x=1, y=2, z=3)
@@ -166,23 +129,6 @@ def test_warns_global_abs_grid_does_not_mutate_original_position() -> None:
     assert pos.y == 2
     assert seq.stage_positions[0].x is None  # sequence copy is updated
     assert seq.stage_positions[0].y is None
-
-
-@pytest.mark.parametrize("global_plan", _ABSOLUTE_GRID_PLANS)
-@pytest.mark.parametrize("sub_plan", _RELATIVE_GRID_PLANS)
-def test_position_with_own_grid_exempt_from_global_absolute_grid(
-    global_plan: dict, sub_plan: Any
-) -> None:
-    """Position with its own sub-grid is exempt from global abs grid x/y clearing."""
-    seq = useq.MDASequence(
-        stage_positions=[
-            useq.Position(x=1, y=2, z=3, sequence={"grid_plan": sub_plan})
-        ],
-        grid_plan=global_plan,
-    )
-    pos = seq.stage_positions[0]
-    assert pos.x == 1
-    assert pos.y == 2
 
 
 @pytest.mark.parametrize("grid_plan", _ABSOLUTE_GRID_PLANS)

--- a/tests/test_stage_positions.py
+++ b/tests/test_stage_positions.py
@@ -81,12 +81,12 @@ def test_position_none_xy_rejected_with_relative_sub_sequence_grid(
 
 
 def test_add_with_none_coordinates() -> None:
-    """__add__ uses the other's value when self coordinate is None."""
+    """__add__ preserves None when self coordinate is None (no fallback to other)."""
     pos = useq.Position(x=None, y=None, z=3)
     rel = useq.RelativePosition(x=5, y=10, z=0)
     result = pos + rel
-    assert result.x == 5
-    assert result.y == 10
+    assert result.x is None
+    assert result.y is None
     assert result.z == 3
 
 

--- a/tests/test_stage_positions.py
+++ b/tests/test_stage_positions.py
@@ -172,6 +172,20 @@ def test_sub_sequence_absolute_grid_warns_and_clears_xy(grid_plan: dict) -> None
     assert pos.z == 3.0
 
 
+def test_warns_global_abs_grid_does_not_mutate_original_position() -> None:
+    """Clearing x/y for a global absolute grid must not mutate the original Position."""
+    pos = useq.Position(x=1, y=2, z=3)
+    with pytest.warns(UserWarning, match="is ignored when using"):
+        seq = useq.MDASequence(
+            stage_positions=[pos],
+            grid_plan={"top": 1, "bottom": -1, "left": 0, "right": 0},
+        )
+    assert pos.x == 1  # original must be untouched
+    assert pos.y == 2
+    assert seq.stage_positions[0].x is None  # sequence view is updated
+    assert seq.stage_positions[0].y is None
+
+
 def test_relative_position_rejected_in_stage_positions() -> None:
     """RelativePosition is always rejected in stage_positions."""
     with pytest.raises(Exception, match="RelativePosition cannot be used"):

--- a/tests/test_time_estimation.py
+++ b/tests/test_time_estimation.py
@@ -129,7 +129,9 @@ SEQS_WITH_SUBSEQS: dict[useq.MDASequence, float | tuple[float, bool]] = {
         channels=[DAPI_10],
         stage_positions=[
             (0, 0),  # 0.01
-            useq.Position(x=1, sequence=useq.MDASequence(grid_plan=GRID_4)),  # 0.04
+            useq.Position(
+                x=1, y=0, sequence=useq.MDASequence(grid_plan=GRID_4)
+            ),  # 0.04
         ],
     ): 0.05,  # 0.01 + 0.04
 }


### PR DESCRIPTION
This PR is linked to this [one-writers PR]( https://github.com/pymmcore-plus/ome-writers/pull/104) and it should improve the yanked `v0.8.3` (https://github.com/pymmcore-plus/useq-schema/pull/254#issuecomment-3947490165):

- Move the absolute grid plan validation from `PositionBase` to `AbsolutePosition`, so `RelativePosition` is not subject to the x/y clearing logic
- Reject `RelativePosition` in `MDASequence.stage_positions` with a clear error message
- Fix `__add__` to fall back to the other operand's value when one side is None (instead of silently dropping it)
- Add `__radd__` support so `RelativePosition` + `AbsolutePosition` works in either order
- Update tests