### PR TITLE
chore: Revert "fix: warn and set to None x and y on positions with absolute grid plans (#254)"

### DIFF
--- a/src/useq/_mda_sequence.py
+++ b/src/useq/_mda_sequence.py
@@ -307,32 +307,6 @@ class MDASequence(UseqModel):
                         "keep_shutter_open_across cannot currently be set on a "
                         "Position sequence"
                     )
-            # it's invalid to have stage positions with x/y coordinates
-            # when using a global absolute grid plan
-            if self.grid_plan is not None and not self.grid_plan.is_relative:
-                new_positions: list[Position] = []
-                modified = False
-                for p in self.stage_positions:
-                    # Positions that have their own grid plan are exempt from this
-                    # warning, since their local grid plans will override the global one
-                    # and they are already validated to be internally consistent.
-                    if (p.x is not None or p.y is not None) and (
-                        p.sequence is None or p.sequence.grid_plan is None
-                    ):
-                        grid_plan_type = type(self.grid_plan).__name__
-                        warn(
-                            f"Position x={p.x!r}, y={p.y!r} is ignored when using a "
-                            f"global absolute grid plan ({grid_plan_type}). "
-                            "Set x=None, y=None on the position to silence this "
-                            "warning. In a future version this will raise an error.",
-                            UserWarning,
-                            stacklevel=2,
-                        )
-                        p = p.model_copy(update={"x": None, "y": None})
-                        modified = True
-                    new_positions.append(p)
-                if modified:
-                    object.__setattr__(self, "stage_positions", tuple(new_positions))
         return self
 
     def __eq__(self, other: Any) -> bool:

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -1,4 +1,3 @@
-import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Generic, Optional, SupportsIndex, TypeVar
 
@@ -88,28 +87,6 @@ class PositionBase(MutableModel):
                 z = value[2]
             value = {"x": x, "y": y, "z": z}
         return value
-
-    @model_validator(mode="after")
-    def _validate_position(self) -> "Self":
-        # x and y should not be set when using an absolute grid plan.
-        if (
-            (self.x is not None or self.y is not None)
-            and self.sequence is not None
-            and self.sequence.grid_plan is not None
-            and not self.sequence.grid_plan.is_relative
-        ):
-            grid = self.sequence.grid_plan
-            warnings.warn(
-                f"Position x={self.x!r}, y={self.y!r} is ignored when a position "
-                f"sequence uses an absolute grid plan ({type(grid).__name__}). "
-                "Set x=None, y=None on the position to silence this warning. "
-                "In a future version this will raise an error.",
-                UserWarning,
-                stacklevel=2,
-            )
-            object.__setattr__(self, "x", None)
-            object.__setattr__(self, "y", None)
-        return self
 
 
 class AbsolutePosition(PositionBase, FrozenModel):

--- a/tests/fixtures/cases.py
+++ b/tests/fixtures/cases.py
@@ -172,6 +172,8 @@ GRID_SUBSEQ_CASES: list[MDATestCase] = [
             stage_positions=[
                 Position(x=0, y=0),
                 Position(
+                    x=10,
+                    y=10,
                     sequence={
                         "grid_plan": GridFromEdges(top=1, bottom=-1, left=0, right=0)
                     },
@@ -600,7 +602,7 @@ GRID_SUBSEQ_CASES: list[MDATestCase] = [
         seq=MDASequence(
             axis_order="tpgcz",
             stage_positions=[
-                Position(z=3),
+                Position(x=0, y=0),
                 Position(
                     name="name",
                     x=10,

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -69,11 +69,7 @@ def test_axis_order_errors() -> None:
 
     # absolute grid_plan with multiple stage positions
 
-    with (
-        pytest.warns(UserWarning, match="Position x=0.0, y=0.0 is ignored"),
-        pytest.warns(UserWarning, match="Position x=10.0, y=10.0 is ignored"),
-        pytest.warns(UserWarning, match="Global grid plan will override"),
-    ):
+    with pytest.warns(UserWarning, match="Global grid plan will override"):
         MDASequence(
             stage_positions=[(0, 0, 0), (10, 10, 10)],
             grid_plan={"top": 1, "bottom": -1, "left": 0, "right": 0},
@@ -88,7 +84,7 @@ def test_axis_order_errors() -> None:
     # if all but one sub-position has a grid plan , is ok
     MDASequence(
         stage_positions=[
-            {"z": 0},
+            (0, 0, 0),
             {"sequence": {"grid_plan": {"rows": 2, "columns": 2}}},
             {
                 "sequence": {
@@ -106,46 +102,6 @@ def test_axis_order_errors() -> None:
                 {"sequence": {"stage_positions": [(10, 10, 10), (20, 20, 20)]}}
             ]
         )
-
-    # x/y on a position is ignored with a global absolute grid
-    # --- GridFromEdges ---
-    with pytest.warns(
-        UserWarning, match="is ignored when using a global absolute grid plan"
-    ):
-        seq = MDASequence(
-            stage_positions=[{"x": 10, "y": 20}],
-            grid_plan={"top": 1, "bottom": -1, "left": 0, "right": 0},
-        )
-    assert seq.stage_positions[0].x is None
-    assert seq.stage_positions[0].y is None
-    # --- GridFromPolygon ---
-    with pytest.warns(
-        UserWarning, match="is ignored when using a global absolute grid plan"
-    ):
-        seq = MDASequence(
-            stage_positions=[{"x": 10, "y": 20}],
-            grid_plan={
-                "vertices": [(0, 0), (4, 0), (2, 4)],
-                "fov_width": 2,
-                "fov_height": 2,
-            },
-        )
-    assert seq.stage_positions[0].x is None
-    assert seq.stage_positions[0].y is None
-
-    # no warning when x/y are None with absolute grids
-    MDASequence(
-        stage_positions=[{}],
-        grid_plan={"top": 1, "bottom": -1, "left": 0, "right": 0},
-    )
-    MDASequence(
-        stage_positions=[{}],
-        grid_plan={
-            "vertices": [(0, 0), (4, 0), (2, 4)],
-            "fov_width": 2,
-            "fov_height": 2,
-        },
-    )
 
 
 @pytest.mark.parametrize("cls", [MDASequence, MDAEvent])

--- a/tests/test_stage_positions.py
+++ b/tests/test_stage_positions.py
@@ -30,33 +30,3 @@ p_inputs = [
 def test_stage_positions(position: Any, pexpectation: Sequence[float]) -> None:
     position = useq.Position.model_validate(position)
     assert (position.x, position.y, position.z) == pexpectation
-
-
-_ABSOLUTE_GRID_PLANS = [
-    pytest.param(
-        {"top": 1, "bottom": -1, "left": 0, "right": 0},
-        id="GridFromEdges",
-    ),
-    pytest.param(
-        {"vertices": [(0, 0), (4, 0), (2, 4)], "fov_width": 2, "fov_height": 2},
-        id="GridFromPolygon",
-    ),
-]
-
-
-@pytest.mark.parametrize("grid_plan", _ABSOLUTE_GRID_PLANS)
-def test_position_warns_on_absolute_sub_sequence_grid(
-    grid_plan: dict,
-) -> None:
-    """Position clears x/y and warns at construction when sub-sequence uses an absolute grid."""
-    with pytest.warns(UserWarning, match="is ignored when a position sequence uses"):
-        pos = useq.Position(x=1, y=2, sequence={"grid_plan": grid_plan})
-    assert pos.x is None
-    assert pos.y is None
-
-
-def test_position_no_warn_on_relative_sub_sequence_grid() -> None:
-    """Position keeps x/y when sub-sequence uses a relative grid."""
-    pos = useq.Position(x=1, y=2, sequence={"grid_plan": {"rows": 2, "columns": 2}})
-    assert pos.x == 1
-    assert pos.y == 2


### PR DESCRIPTION
This reverts commit 48a89b010f7c84be29188c6970976dfe07f3ba03.

needs more consideration.  And we can release the polygon row/col changes without it