### PR TITLE
feat: add Position.properties to be yielded on the first index of each position

### DIFF
--- a/src/useq/_iter_sequence.py
+++ b/src/useq/_iter_sequence.py
@@ -9,7 +9,7 @@ from typing_extensions import TypedDict
 from useq._channel import Channel  # noqa: TC001  # noqa: TCH001
 from useq._enums import AXES, Axis
 from useq._mda_event import Channel as EventChannel
-from useq._mda_event import MDAEvent, ReadOnlyDict
+from useq._mda_event import MDAEvent, PropertyTuple, ReadOnlyDict
 from useq._utils import _has_axes
 from useq._z import AnyZPlan  # noqa: TC001  # noqa: TCH001
 
@@ -30,7 +30,7 @@ class MDAEventDict(TypedDict, total=False):
     y_pos: float | None
     z_pos: float | None
     sequence: MDASequence | None
-    # properties: list[tuple] | None
+    properties: list[PropertyTuple] | None
     metadata: dict
     reset_event_timer: bool
 
@@ -113,6 +113,7 @@ def _iter_sequence(
     event_kwarg_overrides: MDAEventDict | None = None,
     position_offsets: PositionDict | None = None,
     _last_t_idx: int = -1,
+    _last_p_idx: int = -1,
 ) -> Iterator[MDAEvent]:
     """Helper function for `iter_sequence`.
 
@@ -174,6 +175,11 @@ def _iter_sequence(
         event_kwargs.update(_xyzpos(position, channel, sequence.z_plan, grid, z_pos))
         if position and position.name:
             event_kwargs["pos_name"] = position.name
+        # include position properties only when p-index changes
+        p_idx = index.get(Axis.POSITION, -1)
+        if position and position.properties and p_idx != _last_p_idx:
+            event_kwargs["properties"] = list(position.properties)
+        _last_p_idx = p_idx
         if channel:
             event_kwargs["channel"] = EventChannel.model_construct(
                 config=channel.config, group=channel.group
@@ -223,6 +229,7 @@ def _iter_sequence(
                     event_kwarg_overrides=pos_overrides,
                     position_offsets=_offsets,
                     _last_t_idx=_last_t_idx,
+                    _last_p_idx=_last_p_idx,
                 )
                 continue
             # note that position.sequence may be Falsey even if not None, for example

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -6,6 +6,7 @@ import numpy as np
 from pydantic import Field, model_validator
 
 from useq._base_model import FrozenModel, MutableModel
+from useq._mda_event import PropertyTuple
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -44,6 +45,7 @@ class PositionBase(MutableModel):
     z: float | None = None
     name: str | None = None
     sequence: Optional["MDASequence"] = None
+    properties: list[PropertyTuple] | None = None
 
     # excluded from serialization
     row: int | None = Field(default=None, exclude=True)

--- a/tests/fixtures/mda.json
+++ b/tests/fixtures/mda.json
@@ -62,6 +62,7 @@
   "stage_positions": [
     {
       "name": null,
+      "properties": null,
       "sequence": null,
       "x": 10.0,
       "y": 20.0,
@@ -69,6 +70,7 @@
     },
     {
       "name": "test_name",
+      "properties": null,
       "sequence": {
         "autofocus_plan": null,
         "axis_order": [
@@ -103,6 +105,7 @@
           "step": 1.0
         }
       },
+      "properties": null,
       "x": 10.0,
       "y": 20.0,
       "z": 50.0


### PR DESCRIPTION
@ieivanov I'm wondering if this would work for you to close the remainder of #260 (specifically, the case of multi-actuator positioning).  `useq.Position` gains a `properties` field.  usage when setting up a useq MDASequence would look like this:

```python
import useq

seq = useq.MDASequence(
    # core FocusDevices should be set to fast (e.g. galvo/piezo) device.
    setup=MDAEvent(properties=[("Core", "Focus", "PiezoZ")],),
    stage_positions=[
        # ObjectiveZ is the name of your slow z-positioner (e.g. nosepiece motor)
        useq.Position(x=100, y=200, properties=[("ObjectiveZ", "Position", 50.0)]),
        useq.Position(x=300, y=400, properties=[("ObjectiveZ", "Position", 75.0)]),
    ],
    z_plan=useq.ZRangeAround(range=4, step=2),
)
```

the semantics are that each time a position is newly visited, the properties are included in the event:

```python
>>> list(seq)

[
    MDAEvent(index={'p': 0, 'z': 0}, x_pos=100.0, y_pos=200.0, z_pos=-2.0, properties=[PropertyTuple(device_name='ObjectiveZ', property_name='Position', property_value=50.0)]),
    MDAEvent(index={'p': 0, 'z': 1}, x_pos=100.0, y_pos=200.0, z_pos=0.0),
    MDAEvent(index={'p': 0, 'z': 2}, x_pos=100.0, y_pos=200.0, z_pos=2.0),
    MDAEvent(index={'p': 1, 'z': 0}, x_pos=300.0, y_pos=400.0, z_pos=-2.0, properties=[PropertyTuple(device_name='ObjectiveZ', property_name='Position', property_value=75.0)]),
    MDAEvent(index={'p': 1, 'z': 1}, x_pos=300.0, y_pos=400.0, z_pos=0.0),
    MDAEvent(index={'p': 1, 'z': 2}, x_pos=300.0, y_pos=400.0, z_pos=2.0)
]
```

That's a *choice*.  We could also choose to include the props in *every* event yielded by that position, and then it would be up to the Engine to track the diff and not make unnecessary changes (so, a bit simpler to have it done here in useq if that's ok).

on the pymmcore plus side, support for this would look check whether `property_name == Keyword.Position` and treat it specially

```python
    def _set_event_properties(self, properties: Sequence[useq.PropertyTuple]) -> None:
        """Set device properties, using setPosition for stage devices."""
        core = self.mmcore
        for dev, prop, value in properties:
            try:
                if prop == Keyword.Position:
                    dev_type = core.getDeviceType(dev)
                    if dev_type == DeviceType.XYStage:
                        if not isinstance(value, (list, tuple)):
                            logger.warning(
                                "Expected XY position to be a list or tuple, got %s. "
                                "Ignoring.",
                                type(value),
                            )
                            continue
                        x, y, *_ = value
                        core.setXYPosition(dev, float(x), float(y))
                    elif dev_type == DeviceType.Stage:
                        core.setPosition(dev, float(value))
                    else:
                        core.setProperty(dev, prop, value)
                else:
                    core.setProperty(dev, prop, value)
            except Exception as e:
                logger.warning(
                    "Failed to set property %s of device %s. %s", prop, dev, e
                )
```

