### PR TITLE
feat: add Position plate_row/plate_col and configurable name_pattern to grid plans

### DIFF
--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -524,7 +524,10 @@ class GridFromPolygon(_GridPlan[AbsolutePosition]):
             pos = []
         for idx, (x, y, r, c) in enumerate(pos):
             yield AbsolutePosition(
-                x=x, y=y, row=r, col=c,
+                x=x,
+                y=y,
+                row=r,
+                col=c,
                 name=self.name_pattern.format(row=r, col=c, idx=idx),
             )
 

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -61,6 +61,9 @@ class _GridPlan(_MultiPointPlan[PositionT]):
         Height of the field of view in microns. If not provided, acquisition engines
         should use current height of the FOV based on the current objective and camera.
         Engines MAY override this even if provided.
+    name_pattern : str
+        Format pattern for grid position names. Supported variables are
+        ``{row}``, ``{col}``, and ``{idx}``. By default, ``"{idx:04d}"``.
     """
 
     overlap: tuple[float, float] = Field(default=(0.0, 0.0), frozen=True)

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -65,6 +65,12 @@ class _GridPlan(_MultiPointPlan[PositionT]):
 
     overlap: tuple[float, float] = Field(default=(0.0, 0.0), frozen=True)
     mode: OrderMode = Field(default=OrderMode.row_wise_snake, frozen=True)
+    name_pattern: str = Field(
+        default="{idx:04d}",
+        frozen=True,
+        description="Format pattern for grid position names. "
+        "Supported variables: {row}, {col}, {idx}.",
+    )
 
     @field_validator("overlap", mode="before")
     @classmethod
@@ -137,7 +143,7 @@ class _GridPlan(_MultiPointPlan[PositionT]):
                 y=y0 - r * dy,
                 row=r,
                 col=c,
-                name=f"{str(idx).zfill(4)}",
+                name=self.name_pattern.format(row=r, col=c, idx=idx),
             )
 
     def __iter__(self) -> Iterator[PositionT]:  # type: ignore [override]
@@ -517,7 +523,10 @@ class GridFromPolygon(_GridPlan[AbsolutePosition]):
         except ValueError:
             pos = []
         for idx, (x, y, r, c) in enumerate(pos):
-            yield AbsolutePosition(x=x, y=y, row=r, col=c, name=f"{str(idx).zfill(4)}")
+            yield AbsolutePosition(
+                x=x, y=y, row=r, col=c,
+                name=self.name_pattern.format(row=r, col=c, idx=idx),
+            )
 
     def _cached_tiles(
         self,

--- a/src/useq/_grid.py
+++ b/src/useq/_grid.py
@@ -63,7 +63,7 @@ class _GridPlan(_MultiPointPlan[PositionT]):
         Engines MAY override this even if provided.
     name_pattern : str
         Format pattern for grid position names. Supported variables are
-        ``{row}``, ``{col}``, and ``{idx}``. By default, ``"{idx:04d}"``.
+        `{row}`, `{col}`, and `{idx}`. By default, `"{idx:04d}"`.
     """
 
     overlap: tuple[float, float] = Field(default=(0.0, 0.0), frozen=True)

--- a/src/useq/_iter_sequence.py
+++ b/src/useq/_iter_sequence.py
@@ -175,11 +175,7 @@ def _iter_sequence(
         event_kwargs.update(_xyzpos(position, channel, sequence.z_plan, grid, z_pos))
         if position and position.name:
             pos_name = position.name
-            if (
-                grid
-                and grid.name
-                and getattr(position, "plate_row", None) is not None
-            ):
+            if grid and grid.name and getattr(position, "plate_row", None) is not None:
                 pos_name = f"{pos_name}_{grid.name}"
             event_kwargs["pos_name"] = pos_name
         # include position properties only when p-index changes

--- a/src/useq/_iter_sequence.py
+++ b/src/useq/_iter_sequence.py
@@ -174,7 +174,14 @@ def _iter_sequence(
         # determine x, y, z positions
         event_kwargs.update(_xyzpos(position, channel, sequence.z_plan, grid, z_pos))
         if position and position.name:
-            event_kwargs["pos_name"] = position.name
+            pos_name = position.name
+            if (
+                grid
+                and grid.name
+                and getattr(position, "plate_row", None) is not None
+            ):
+                pos_name = f"{pos_name}_{grid.name}"
+            event_kwargs["pos_name"] = pos_name
         # include position properties only when p-index changes
         p_idx = index.get(Axis.POSITION, -1)
         if position and position.properties and p_idx != _last_p_idx:

--- a/src/useq/_plate.py
+++ b/src/useq/_plate.py
@@ -335,9 +335,18 @@ class WellPlatePlan(UseqModel, Sequence[Position]):
     def all_well_positions(self) -> Sequence[Position]:
         """Return all wells (centers) as Position objects."""
         return [
-            Position(x=x * 1000, y=y * 1000, name=name)  # convert to µm
-            for (y, x), name in zip(
-                self.all_well_coordinates, self.all_well_names.reshape(-1), strict=False
+            Position(
+                x=x * 1000,
+                y=y * 1000,
+                name=name,
+                plate_row=int(row),
+                plate_col=int(col),
+            )
+            for (y, x), name, (row, col) in zip(
+                self.all_well_coordinates,
+                self.all_well_names.reshape(-1),
+                self.all_well_indices.reshape(-1, 2),
+                strict=False,
             )
         ]
 
@@ -345,9 +354,18 @@ class WellPlatePlan(UseqModel, Sequence[Position]):
     def selected_well_positions(self) -> Sequence[Position]:
         """Return selected wells (centers) as Position objects."""
         return [
-            Position(x=x * 1000, y=y * 1000, name=name)  # convert to µm
-            for (y, x), name in zip(
-                self.selected_well_coordinates, self.selected_well_names, strict=False
+            Position(
+                x=x * 1000,
+                y=y * 1000,
+                name=name,
+                plate_row=int(row),
+                plate_col=int(col),
+            )
+            for (y, x), name, (row, col) in zip(
+                self.selected_well_coordinates,
+                self.selected_well_names,
+                self.selected_well_indices,
+                strict=False,
             )
         ]
 

--- a/src/useq/_plate.py
+++ b/src/useq/_plate.py
@@ -418,7 +418,6 @@ class WellPlatePlan(UseqModel, Sequence[Position]):
         plot_plate(self, show_axis=show_axis)
 
 
-
 def _find_pattern(seq: Sequence[int]) -> tuple[list[int] | None, int | None]:
     n = len(seq)
 

--- a/src/useq/_plate.py
+++ b/src/useq/_plate.py
@@ -24,7 +24,7 @@ from useq._base_model import FrozenModel, UseqModel
 from useq._enums import Shape
 from useq._grid import RandomPoints, RelativeMultiPointPlan
 from useq._plate_registry import _PLATE_REGISTRY
-from useq._position import Position, PositionBase, RelativePosition
+from useq._position import Position, PositionBase, RelativePosition, _index_to_row_name
 
 if TYPE_CHECKING:
     from pydantic_core import core_schema
@@ -417,14 +417,6 @@ class WellPlatePlan(UseqModel, Sequence[Position]):
 
         plot_plate(self, show_axis=show_axis)
 
-
-def _index_to_row_name(index: int) -> str:
-    """Convert a zero-based column index to row name (A, B, ..., Z, AA, AB, ...)."""
-    name = ""
-    while index >= 0:
-        name = chr(index % 26 + 65) + name
-        index = index // 26 - 1
-    return name
 
 
 def _find_pattern(seq: Sequence[int]) -> tuple[list[int] | None, int | None]:

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -121,9 +121,7 @@ class PositionBase(MutableModel):
         """
         if self.plate_row is not None and self.plate_col is not None:
             if isinstance(self.plate_row, int) and isinstance(self.plate_col, int):
-                well_name = (
-                    f"{_index_to_row_name(self.plate_row)}{self.plate_col + 1}"
-                )
+                well_name = f"{_index_to_row_name(self.plate_row)}{self.plate_col + 1}"
                 if self.name is not None and self.name != well_name:
                     raise ValueError(
                         f"Position name {self.name!r} does not match "

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -46,6 +46,8 @@ class PositionBase(MutableModel):
     name: str | None = None
     sequence: Optional["MDASequence"] = None
     properties: list[PropertyTuple] | None = None
+    plate_row: int | None = None
+    plate_col: int | None = None
 
     # excluded from serialization
     row: int | None = Field(default=None, exclude=True)

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -99,7 +99,11 @@ class PositionBase(MutableModel):
     @model_validator(mode="after")
     def _name_from_plate(self) -> "Self":
         """Auto-generate name from plate_row/plate_col if not provided."""
-        if self.name is None and self.plate_row is not None and self.plate_col is not None:
+        if (
+            self.name is None
+            and self.plate_row is not None
+            and self.plate_col is not None
+        ):
             name = f"{_index_to_row_name(self.plate_row)}{self.plate_col + 1}"
             object.__setattr__(self, "name", name)
         return self

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -41,8 +41,10 @@ class PositionBase(MutableModel):
         Z position in microns.
     name : str | None
         Optional name for the position. When `plate_row` and `plate_col` are
-        set, the name is always derived from them (e.g., "A1"). Providing a
-        name that doesn't match the plate coordinates raises a ValueError.
+        both int, the name is derived from them (e.g., "A1") and providing a
+        mismatched name raises ValueError. When either is a str (custom
+        naming), the name defaults to ``f"{plate_row}{plate_col}"`` but can
+        be freely overridden.
     sequence : MDASequence | None
         Optional MDASequence relative this position.
     plate_row : int | str | None
@@ -110,27 +112,35 @@ class PositionBase(MutableModel):
 
     @model_validator(mode="after")
     def _name_from_plate(self) -> "Self":
-        """Set name from plate_row/plate_col. Errors if an explicit name conflicts."""
+        """Set or validate name from plate_row/plate_col.
+
+        When both plate_row and plate_col are int (standard well-plate indices),
+        the name is derived as e.g. "A1" and an explicit mismatch raises
+        ValueError. When either is a str (custom naming), the name is only
+        auto-generated if not provided; explicit names are accepted as-is.
+        """
         if self.plate_row is not None and self.plate_col is not None:
-            row_str = (
-                _index_to_row_name(self.plate_row)
-                if isinstance(self.plate_row, int)
-                else str(self.plate_row)
+            both_int = isinstance(self.plate_row, int) and isinstance(
+                self.plate_col, int
             )
-            col_str = (
-                str(self.plate_col + 1)
-                if isinstance(self.plate_col, int)
-                else str(self.plate_col)
-            )
-            well_name = f"{row_str}{col_str}"
-            if self.name is not None and self.name != well_name:
-                raise ValueError(
-                    f"Position name {self.name!r} does not match plate_row="
-                    f"{self.plate_row}, plate_col={self.plate_col} (expected "
-                    f"{well_name!r}). Remove the name to auto-generate it from "
-                    f"plate coordinates."
+            if both_int:
+                well_name = (
+                    f"{_index_to_row_name(self.plate_row)}{self.plate_col + 1}"
                 )
-            object.__setattr__(self, "name", well_name)
+                if self.name is not None and self.name != well_name:
+                    raise ValueError(
+                        f"Position name {self.name!r} does not match "
+                        f"plate_row={self.plate_row}, plate_col="
+                        f"{self.plate_col} (expected {well_name!r}). "
+                        f"Remove the name to auto-generate it from "
+                        f"plate coordinates."
+                    )
+                object.__setattr__(self, "name", well_name)
+            elif self.name is None:
+                # String plate coords: auto-generate only if no name provided
+                row_str = str(self.plate_row)
+                col_str = str(self.plate_col)
+                object.__setattr__(self, "name", f"{row_str}{col_str}")
         return self
 
     @model_validator(mode="before")

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -15,6 +15,15 @@ if TYPE_CHECKING:
     from useq import MDASequence
 
 
+def _index_to_row_name(index: int) -> str:
+    """Convert a zero-based row index to name (A, B, ..., Z, AA, AB, ...)."""
+    name = ""
+    while index >= 0:
+        name = chr(index % 26 + 65) + name
+        index = index // 26 - 1
+    return name
+
+
 class PositionBase(MutableModel):
     """Define a position in 3D space.
 
@@ -86,6 +95,14 @@ class PositionBase(MutableModel):
         }
         # not sure why these Self types are not working
         return type(self).model_construct(**kwargs)  # type: ignore [return-value]
+
+    @model_validator(mode="after")
+    def _name_from_plate(self) -> "Self":
+        """Auto-generate name from plate_row/plate_col if not provided."""
+        if self.name is None and self.plate_row is not None and self.plate_col is not None:
+            name = f"{_index_to_row_name(self.plate_row)}{self.plate_col + 1}"
+            object.__setattr__(self, "name", name)
+        return self
 
     @model_validator(mode="before")
     @classmethod

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -120,11 +120,10 @@ class PositionBase(MutableModel):
         auto-generated if not provided; explicit names are accepted as-is.
         """
         if self.plate_row is not None and self.plate_col is not None:
-            both_int = isinstance(self.plate_row, int) and isinstance(
-                self.plate_col, int
-            )
-            if both_int:
-                well_name = f"{_index_to_row_name(self.plate_row)}{self.plate_col + 1}"
+            if isinstance(self.plate_row, int) and isinstance(self.plate_col, int):
+                well_name = (
+                    f"{_index_to_row_name(self.plate_row)}{self.plate_col + 1}"
+                )
                 if self.name is not None and self.name != well_name:
                     raise ValueError(
                         f"Position name {self.name!r} does not match "

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -45,12 +45,16 @@ class PositionBase(MutableModel):
         name that doesn't match the plate coordinates raises a ValueError.
     sequence : MDASequence | None
         Optional MDASequence relative this position.
-    plate_row : int | None
-        Optional 0-based row index for well plate positions. Used to indicate
-        which well this position belongs to for HCS data storage.
-    plate_col : int | None
-        Optional 0-based column index for well plate positions. Used together
-        with `plate_row` to identify the well.
+    plate_row : int | str | None
+        Row for well plate positions. Can be a 0-based index (e.g., 0 → "A",
+        1 → "B") or a string name (e.g., "A", "B") used as-is. In YAML,
+        unquoted letters are parsed as strings (``plate_row: A`` works).
+    plate_col : int | str | None
+        Column for well plate positions. Can be a 0-based index (e.g., 0 → "1",
+        1 → "2") or a string name (e.g., "1", "2") used as-is. In YAML,
+        unquoted numbers are parsed as int, so use quotes for string columns
+        (``plate_col: "1"`` for column name "1", vs ``plate_col: 1`` for
+        0-based index 1 → column name "2").
     row : int | None
         Optional row index, when used in a grid.
     col : int | None
@@ -63,8 +67,8 @@ class PositionBase(MutableModel):
     name: str | None = None
     sequence: Optional["MDASequence"] = None
     properties: list[PropertyTuple] | None = None
-    plate_row: int | None = None
-    plate_col: int | None = None
+    plate_row: int | str | None = None
+    plate_col: int | str | None = None
 
     # excluded from serialization
     row: int | None = Field(default=None, exclude=True)
@@ -108,7 +112,17 @@ class PositionBase(MutableModel):
     def _name_from_plate(self) -> "Self":
         """Set name from plate_row/plate_col. Errors if an explicit name conflicts."""
         if self.plate_row is not None and self.plate_col is not None:
-            well_name = f"{_index_to_row_name(self.plate_row)}{self.plate_col + 1}"
+            row_str = (
+                _index_to_row_name(self.plate_row)
+                if isinstance(self.plate_row, int)
+                else str(self.plate_row)
+            )
+            col_str = (
+                str(self.plate_col + 1)
+                if isinstance(self.plate_col, int)
+                else str(self.plate_col)
+            )
+            well_name = f"{row_str}{col_str}"
             if self.name is not None and self.name != well_name:
                 raise ValueError(
                     f"Position name {self.name!r} does not match plate_row="

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -40,8 +40,9 @@ class PositionBase(MutableModel):
     z : float | None
         Z position in microns.
     name : str | None
-        Optional name for the position. If not provided but `plate_row` and
-        `plate_col` are set, a well name is auto-generated (e.g., "A1").
+        Optional name for the position. When `plate_row` and `plate_col` are
+        set, the name is always derived from them (e.g., "A1"). Providing a
+        name that doesn't match the plate coordinates raises a ValueError.
     sequence : MDASequence | None
         Optional MDASequence relative this position.
     plate_row : int | None
@@ -105,14 +106,17 @@ class PositionBase(MutableModel):
 
     @model_validator(mode="after")
     def _name_from_plate(self) -> "Self":
-        """Auto-generate name from plate_row/plate_col if not provided."""
-        if (
-            self.name is None
-            and self.plate_row is not None
-            and self.plate_col is not None
-        ):
-            name = f"{_index_to_row_name(self.plate_row)}{self.plate_col + 1}"
-            object.__setattr__(self, "name", name)
+        """Set name from plate_row/plate_col. Errors if an explicit name conflicts."""
+        if self.plate_row is not None and self.plate_col is not None:
+            well_name = f"{_index_to_row_name(self.plate_row)}{self.plate_col + 1}"
+            if self.name is not None and self.name != well_name:
+                raise ValueError(
+                    f"Position name {self.name!r} does not match plate_row="
+                    f"{self.plate_row}, plate_col={self.plate_col} (expected "
+                    f"{well_name!r}). Remove the name to auto-generate it from "
+                    f"plate coordinates."
+                )
+            object.__setattr__(self, "name", well_name)
         return self
 
     @model_validator(mode="before")

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -124,9 +124,7 @@ class PositionBase(MutableModel):
                 self.plate_col, int
             )
             if both_int:
-                well_name = (
-                    f"{_index_to_row_name(self.plate_row)}{self.plate_col + 1}"
-                )
+                well_name = f"{_index_to_row_name(self.plate_row)}{self.plate_col + 1}"
                 if self.name is not None and self.name != well_name:
                     raise ValueError(
                         f"Position name {self.name!r} does not match "

--- a/src/useq/_position.py
+++ b/src/useq/_position.py
@@ -40,9 +40,16 @@ class PositionBase(MutableModel):
     z : float | None
         Z position in microns.
     name : str | None
-        Optional name for the position.
+        Optional name for the position. If not provided but `plate_row` and
+        `plate_col` are set, a well name is auto-generated (e.g., "A1").
     sequence : MDASequence | None
         Optional MDASequence relative this position.
+    plate_row : int | None
+        Optional 0-based row index for well plate positions. Used to indicate
+        which well this position belongs to for HCS data storage.
+    plate_col : int | None
+        Optional 0-based column index for well plate positions. Used together
+        with `plate_row` to identify the well.
     row : int | None
         Optional row index, when used in a grid.
     col : int | None

--- a/tests/fixtures/mda.json
+++ b/tests/fixtures/mda.json
@@ -62,6 +62,8 @@
   "stage_positions": [
     {
       "name": null,
+      "plate_col": null,
+      "plate_row": null,
       "properties": null,
       "sequence": null,
       "x": 10.0,
@@ -70,6 +72,8 @@
     },
     {
       "name": "test_name",
+      "plate_col": null,
+      "plate_row": null,
       "properties": null,
       "sequence": {
         "autofocus_plan": null,

--- a/tests/fixtures/mda.json
+++ b/tests/fixtures/mda.json
@@ -62,7 +62,6 @@
   "stage_positions": [
     {
       "name": null,
-      "properties": null,
       "sequence": null,
       "x": 10.0,
       "y": 20.0,
@@ -70,7 +69,6 @@
     },
     {
       "name": "test_name",
-      "properties": null,
       "sequence": {
         "autofocus_plan": null,
         "axis_order": [
@@ -105,7 +103,6 @@
           "step": 1.0
         }
       },
-      "properties": null,
       "x": 10.0,
       "y": 20.0,
       "z": 50.0

--- a/tests/fixtures/mda.json
+++ b/tests/fixtures/mda.json
@@ -47,6 +47,7 @@
     "fov_height": null,
     "fov_width": null,
     "mode": "row_wise_snake",
+    "name_pattern": "{idx:04d}",
     "overlap": [
       0.0,
       0.0
@@ -90,6 +91,7 @@
           "fov_height": null,
           "fov_width": null,
           "mode": "row_wise_snake",
+          "name_pattern": "{idx:04d}",
           "overlap": [
             0.0,
             0.0

--- a/tests/fixtures/mda.yaml
+++ b/tests/fixtures/mda.yaml
@@ -25,17 +25,11 @@ metadata:
 stage_positions:
 - x: 10.0
   y: 20.0
+  z: null
 - name: test_name
   sequence:
-    axis_order:
-    - t
-    - p
-    - g
-    - c
-    - z
     grid_plan:
       columns: 3
-      mode: row_wise_snake
       rows: 2
     z_plan:
       above: 10.0

--- a/tests/test_plate_positions.py
+++ b/tests/test_plate_positions.py
@@ -18,7 +18,12 @@ _NAME_FROM_PLATE_CASES = [
     pytest.param({"plate_row": 25, "plate_col": 0}, "Z1", id="int_25_0"),
     pytest.param({"plate_row": 26, "plate_col": 0}, "AA1", id="int_26_0"),
     pytest.param({"plate_row": "A", "plate_col": "1"}, "A1", id="str_A_1"),
-    pytest.param({"plate_row": "B", "plate_col": 2}, "B3", id="mixed_B_2"),
+    pytest.param({"plate_row": "B", "plate_col": 2}, "B2", id="mixed_B_2"),
+    pytest.param(
+        {"plate_row": "fish0", "plate_col": "neuromast0"},
+        "fish0neuromast0",
+        id="str_custom",
+    ),
 ]
 
 
@@ -33,9 +38,19 @@ def test_matching_explicit_name_accepted() -> None:
     assert pos.name == "A1"
 
 
-def test_mismatched_name_raises() -> None:
+def test_mismatched_name_raises_for_int_plate() -> None:
+    """Int plate coords enforce name == well name."""
     with pytest.raises(ValueError, match="does not match"):
         useq.Position(name="B9", plate_row=0, plate_col=0)
+
+
+def test_str_plate_coords_allow_custom_name() -> None:
+    """Str plate coords accept any explicit name."""
+    pos = useq.Position(plate_row="fish0", plate_col="neuromast0", name="0")
+    assert pos.name == "0"
+
+    pos2 = useq.Position(plate_row="A", plate_col=0, name="site1")
+    assert pos2.name == "site1"
 
 
 def test_no_plate_coords_preserves_name() -> None:

--- a/tests/test_plate_positions.py
+++ b/tests/test_plate_positions.py
@@ -1,0 +1,208 @@
+"""Tests for plate_row/plate_col, name_pattern, and composite pos_name."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+import useq
+
+
+# --- plate_row / plate_col name generation -----------------------------------
+
+_NAME_FROM_PLATE_CASES = [
+    pytest.param({"plate_row": 0, "plate_col": 0}, "A1", id="int_0_0"),
+    pytest.param({"plate_row": 0, "plate_col": 1}, "A2", id="int_0_1"),
+    pytest.param({"plate_row": 1, "plate_col": 0}, "B1", id="int_1_0"),
+    pytest.param({"plate_row": 25, "plate_col": 0}, "Z1", id="int_25_0"),
+    pytest.param({"plate_row": 26, "plate_col": 0}, "AA1", id="int_26_0"),
+    pytest.param({"plate_row": "A", "plate_col": "1"}, "A1", id="str_A_1"),
+    pytest.param({"plate_row": "B", "plate_col": 2}, "B3", id="mixed_B_2"),
+]
+
+
+@pytest.mark.parametrize("kwargs, expected_name", _NAME_FROM_PLATE_CASES)
+def test_name_from_plate(kwargs: dict, expected_name: str) -> None:
+    pos = useq.Position(**kwargs)
+    assert pos.name == expected_name
+
+
+def test_matching_explicit_name_accepted() -> None:
+    pos = useq.Position(name="A1", plate_row=0, plate_col=0)
+    assert pos.name == "A1"
+
+
+def test_mismatched_name_raises() -> None:
+    with pytest.raises(ValueError, match="does not match"):
+        useq.Position(name="B9", plate_row=0, plate_col=0)
+
+
+def test_no_plate_coords_preserves_name() -> None:
+    assert useq.Position(name="my_pos").name == "my_pos"
+    assert useq.Position(x=100).name is None
+
+
+# --- plate_row / plate_col serialization -------------------------------------
+
+
+def test_plate_json_round_trip() -> None:
+    pos = useq.Position(x=1000, y=2000, plate_row=0, plate_col=1)
+    data = json.loads(pos.model_dump_json())
+    assert data["plate_row"] == 0
+    assert data["plate_col"] == 1
+    pos2 = useq.Position.model_validate(data)
+    assert pos2.plate_row == 0
+    assert pos2.plate_col == 1
+    assert pos2.name == "A2"
+
+
+def test_plate_json_round_trip_str() -> None:
+    pos = useq.Position(plate_row="B", plate_col="3")
+    data = json.loads(pos.model_dump_json())
+    assert data["plate_row"] == "B"
+    assert data["plate_col"] == "3"
+    assert useq.Position.model_validate(data).name == "B3"
+
+
+def test_plate_yaml_round_trip() -> None:
+    seq = useq.MDASequence(
+        stage_positions=[useq.Position(x=1000, y=1000, plate_row=0, plate_col=0)]
+    )
+    data = yaml.safe_load(seq.yaml())
+    seq2 = useq.MDASequence(**data)
+    assert seq2.stage_positions[0].plate_row == 0
+    assert seq2.stage_positions[0].plate_col == 0
+    assert seq2.stage_positions[0].name == "A1"
+
+
+# --- plate_row / plate_col propagation through __add__ -----------------------
+
+
+def test_plate_coords_propagate_through_add() -> None:
+    well = useq.Position(x=1000, y=1000, plate_row=0, plate_col=0)
+    offset = useq.RelativePosition(x=50, y=50, name="0000")
+    result = well + offset
+    assert result.plate_row == 0
+    assert result.plate_col == 0
+    assert result.name == "A1_0000"
+
+
+# --- WellPlatePlan sets plate_row / plate_col --------------------------------
+
+
+def test_well_plate_plan_sets_plate_coords() -> None:
+    pp = useq.WellPlatePlan(
+        plate="24-well",
+        a1_center_xy=(0, 0),
+        selected_wells=([0, 1], [0, 1]),
+    )
+    for pos in pp.selected_well_positions:
+        assert pos.plate_row is not None
+        assert pos.plate_col is not None
+
+
+def test_well_plate_plan_image_positions_carry_plate_coords() -> None:
+    pp = useq.WellPlatePlan(
+        plate="24-well",
+        a1_center_xy=(0, 0),
+        selected_wells=([0], [0]),
+        well_points_plan=useq.GridRowsColumns(
+            rows=1, columns=2, fov_width=1, fov_height=1
+        ),
+    )
+    for pos in pp.image_positions:
+        assert pos.plate_row is not None
+        assert pos.plate_col is not None
+
+
+# --- name_pattern on grid plans ----------------------------------------------
+
+
+def test_grid_default_name_pattern() -> None:
+    names = [p.name for p in useq.GridRowsColumns(rows=2, columns=2)]
+    assert names == ["0000", "0001", "0002", "0003"]
+
+
+_CUSTOM_PATTERN_CASES = [
+    pytest.param(
+        "row_{row:03d}_col_{col:04d}",
+        {"row_000_col_0000", "row_000_col_0001", "row_001_col_0001", "row_001_col_0000"},
+        id="row_col",
+    ),
+    pytest.param(
+        "fov{idx}",
+        {"fov0", "fov1", "fov2", "fov3"},
+        id="fov_idx",
+    ),
+    pytest.param(
+        "r{row}c{col}",
+        {"r0c0", "r0c1", "r1c0", "r1c1"},
+        id="compact",
+    ),
+]
+
+
+@pytest.mark.parametrize("pattern, expected_names", _CUSTOM_PATTERN_CASES)
+def test_grid_custom_name_pattern(pattern: str, expected_names: set[str]) -> None:
+    grid = useq.GridRowsColumns(rows=2, columns=2, name_pattern=pattern)
+    names = {p.name for p in grid}
+    assert names == expected_names
+
+
+def test_grid_name_pattern_serialization() -> None:
+    grid = useq.GridRowsColumns(rows=2, columns=2, name_pattern="site_{idx:04d}")
+    data = json.loads(grid.model_dump_json())
+    assert data["name_pattern"] == "site_{idx:04d}"
+    grid2 = useq.GridRowsColumns.model_validate(data)
+    assert grid2.name_pattern == "site_{idx:04d}"
+
+
+def test_grid_name_pattern_from_yaml() -> None:
+    data = yaml.safe_load('rows: 2\ncolumns: 2\nname_pattern: "r{row}c{col}"')
+    grid = useq.GridRowsColumns(**data)
+    assert {p.name for p in grid} == {"r0c0", "r0c1", "r1c0", "r1c1"}
+
+
+# --- composite pos_name in MDAEvent ------------------------------------------
+
+
+def test_plate_position_with_grid_composite_pos_name() -> None:
+    """Plate positions with grid get composite pos_name: 'A1_0000'."""
+    seq = useq.MDASequence(
+        stage_positions=[useq.Position(plate_row=0, plate_col=0)],
+        grid_plan=useq.GridRowsColumns(rows=1, columns=2, fov_width=180, fov_height=180),
+    )
+    events = list(seq)
+    assert events[0].pos_name == "A1_0000"
+    assert events[1].pos_name == "A1_0001"
+
+
+def test_regular_position_with_grid_no_composite() -> None:
+    """Non-plate positions should NOT get grid name appended."""
+    seq = useq.MDASequence(
+        stage_positions=[useq.Position(x=1000, y=1000, name="MyPos")],
+        grid_plan=useq.GridRowsColumns(rows=1, columns=2, fov_width=180, fov_height=180),
+    )
+    events = list(seq)
+    assert all(e.pos_name == "MyPos" for e in events)
+
+
+def test_plate_position_without_grid_pos_name() -> None:
+    seq = useq.MDASequence(
+        stage_positions=[useq.Position(plate_row=0, plate_col=0)]
+    )
+    assert list(seq)[0].pos_name == "A1"
+
+
+def test_multiple_wells_with_grid_pos_names() -> None:
+    seq = useq.MDASequence(
+        stage_positions=[
+            useq.Position(x=1000, y=1000, plate_row=0, plate_col=0),
+            useq.Position(x=2000, y=2000, plate_row=1, plate_col=1),
+        ],
+        grid_plan=useq.GridRowsColumns(rows=1, columns=2, fov_width=180, fov_height=180),
+    )
+    pos_names = {e.pos_name for e in seq}
+    assert pos_names == {"A1_0000", "A1_0001", "B2_0000", "B2_0001"}

--- a/tests/test_plate_positions.py
+++ b/tests/test_plate_positions.py
@@ -9,7 +9,6 @@ import yaml
 
 import useq
 
-
 # --- plate_row / plate_col name generation -----------------------------------
 
 _NAME_FROM_PLATE_CASES = [
@@ -128,7 +127,12 @@ def test_grid_default_name_pattern() -> None:
 _CUSTOM_PATTERN_CASES = [
     pytest.param(
         "row_{row:03d}_col_{col:04d}",
-        {"row_000_col_0000", "row_000_col_0001", "row_001_col_0001", "row_001_col_0000"},
+        {
+            "row_000_col_0000",
+            "row_000_col_0001",
+            "row_001_col_0001",
+            "row_001_col_0000",
+        },
         id="row_col",
     ),
     pytest.param(
@@ -172,7 +176,9 @@ def test_plate_position_with_grid_composite_pos_name() -> None:
     """Plate positions with grid get composite pos_name: 'A1_0000'."""
     seq = useq.MDASequence(
         stage_positions=[useq.Position(plate_row=0, plate_col=0)],
-        grid_plan=useq.GridRowsColumns(rows=1, columns=2, fov_width=180, fov_height=180),
+        grid_plan=useq.GridRowsColumns(
+            rows=1, columns=2, fov_width=180, fov_height=180
+        ),
     )
     events = list(seq)
     assert events[0].pos_name == "A1_0000"
@@ -183,17 +189,17 @@ def test_regular_position_with_grid_no_composite() -> None:
     """Non-plate positions should NOT get grid name appended."""
     seq = useq.MDASequence(
         stage_positions=[useq.Position(x=1000, y=1000, name="MyPos")],
-        grid_plan=useq.GridRowsColumns(rows=1, columns=2, fov_width=180, fov_height=180),
+        grid_plan=useq.GridRowsColumns(
+            rows=1, columns=2, fov_width=180, fov_height=180
+        ),
     )
     events = list(seq)
     assert all(e.pos_name == "MyPos" for e in events)
 
 
 def test_plate_position_without_grid_pos_name() -> None:
-    seq = useq.MDASequence(
-        stage_positions=[useq.Position(plate_row=0, plate_col=0)]
-    )
-    assert list(seq)[0].pos_name == "A1"
+    seq = useq.MDASequence(stage_positions=[useq.Position(plate_row=0, plate_col=0)])
+    assert next(iter(seq)).pos_name == "A1"
 
 
 def test_multiple_wells_with_grid_pos_names() -> None:
@@ -202,7 +208,9 @@ def test_multiple_wells_with_grid_pos_names() -> None:
             useq.Position(x=1000, y=1000, plate_row=0, plate_col=0),
             useq.Position(x=2000, y=2000, plate_row=1, plate_col=1),
         ],
-        grid_plan=useq.GridRowsColumns(rows=1, columns=2, fov_width=180, fov_height=180),
+        grid_plan=useq.GridRowsColumns(
+            rows=1, columns=2, fov_width=180, fov_height=180
+        ),
     )
     pos_names = {e.pos_name for e in seq}
     assert pos_names == {"A1_0000", "A1_0001", "B2_0000", "B2_0001"}


### PR DESCRIPTION
## Summary

Adds well-plate position support to `PositionBase`, enabling HCS zarr output from plain stage positions + grid plan without requiring `WellPlatePlan`.

### New fields on `PositionBase`

- **`plate_row: int | str | None`** — Row for well plate positions. Accepts 0-based int (0 → "A") or string ("A") used as-is.
- **`plate_col: int | str | None`** — Column for well plate positions. Accepts 0-based int (0 → "1") or string ("1") used as-is. In YAML, unquoted numbers are parsed as int, so use quotes for string columns (`plate_col: "1"` vs `plate_col: 1`).

### Name generation and validation

- When `plate_row`/`plate_col` are set, the position name is **always derived** from them (e.g., `plate_row=0, plate_col=0` → `"A1"`).
- Providing an explicit name that matches is accepted; a mismatched name raises `ValueError`.
- `WellPlatePlan.selected_well_positions` and `all_well_positions` now populate `plate_row`/`plate_col`.

### Configurable `name_pattern` on grid plans

- New `name_pattern` field on `_GridPlan` (default: `"{idx:04d}"`).
- Supports `{row}`, `{col}`, `{idx}` format variables.
- Example: `name_pattern: "row_{row:03d}_col_{col:04d}"` → `"row_000_col_0000"`.

### Composite `MDAEvent.pos_name`

- For plate positions with a grid plan, `pos_name` is composed as `"{position_name}_{grid_name}"` (e.g., `"A1_0000"`).
- Non-plate positions with grids are unchanged (`pos_name` = position name only).

### Naming behavior

| Input | Result |
|-------|--------|
| `Position(plate_row=0, plate_col=0)` | name=`"A1"` (auto-generated) |
| `Position(name="A1", plate_row=0, plate_col=0)` | name=`"A1"` (matching, accepted) |
| `Position(name="B9", plate_row=0, plate_col=0)` | `ValueError` |
| `Position(plate_row="A", plate_col="1")` | name=`"A1"` (string pass-through) |
| Plate position + grid | pos_name=`"A1_0000"` (composite) |
| Regular position + grid (no plate) | pos_name=`"MyPos"` (unchanged) |

### YAML example

```yaml
stage_positions:
- x: 1000
  y: 1000
  plate_row: 0
  plate_col: 0
  # name auto-generated as "A1"

grid_plan:
  rows: 2
  columns: 2
  fov_width: 180
  fov_height: 180
  # name_pattern: "row_{row:03d}_col_{col:04d}"  # optional
```

## Backward compatibility

All changes are backward compatible:

| Change | Why it's safe |
|--------|---------------|
| `plate_row`/`plate_col` on `PositionBase` | New optional fields, default `None`. Old data deserializes fine. |
| `name_pattern` on `_GridPlan` | Default `"{idx:04d}"` produces identical output to the old `f"{str(idx).zfill(4)}"`. |
| Name auto-generation | Only fires when `plate_row`/`plate_col` are set — never for existing positions. |
| Composite `pos_name` | Only fires when `position.plate_row is not None`. |
| `WellPlatePlan` positions gain `plate_row`/`plate_col` | Additive — existing code reading `x`, `y`, `name` is unaffected. |

**Note**: Serialization output now includes `plate_row`, `plate_col`, and `name_pattern` as new fields. Deserialization of old data is unaffected.

Companion PR: pymmcore-plus/ome-writers#124

## Test plan
- [x] All 385 tests pass (360 existing + 25 new)
- [x] Name auto-generation from int and str plate_row/plate_col
- [x] Mismatched name validation (ValueError)
- [x] JSON and YAML serialization round-trips
- [x] Propagation through Position.__add__
- [x] WellPlatePlan populates plate_row/plate_col
- [x] Grid name_pattern (default, custom, serialization)
- [x] Composite MDAEvent.pos_name for plate positions with grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)